### PR TITLE
Add example with Emscripten resource management patterns to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This proposal is motivated by a number of cases:
   - ECMAScript Iterators: `iterator.return()`
   - WHATWG Stream Readers: `reader.releaseLock()`
   - NodeJS FileHandles: `handle.close()`
+  - Emscripten C++ objects handles: `Module._free(ptr) obj.delete() Module.destroy(obj)`
 - Avoiding common footguns when managing resources:
   ```js
   const reader = stream.getReader();


### PR DESCRIPTION
A small change to `README.md` to mention the patterns of WebAssembly modules memory management in [`emscripten`](https://emscripten.org/).

[Embind docs](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#memory-management).
[WebIDL binder docs.](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html#using-c-classes-in-javascript)