### PR TITLE
Normative: Make `AggregateError` match other proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,8 +663,8 @@ This proposal also adds the `AggregateError` class for cases where exceptions ar
 
 ```ts
 declare class AggregateError extends Error {
-  errors: unknown[];
   constructor(errors: Iterable<unknown>, message?: string);
+  get errors(): unknown[];
 }
 ```
 

--- a/spec/sec-error-objects-patch.html
+++ b/spec/sec-error-objects-patch.html
@@ -4,25 +4,26 @@
     <h1><ins>AggregateError Objects</ins></h1>
     <p>An AggregateError Object is an extended _NativeError_ object that encapsulates multiple errors.</p>
     <emu-note>NOTE: This is based on the same design for AggregateError in the <a href="https://tc39.es/proposal-promise-any/#sec-native-error-types-used-in-this-standard-aggregateerror">Promise.any</a> proposal.</emu-note>
+
     <emu-clause id="sec-aggregateerror-constructor">
       <h1>The AggregateError Constructor</h1>
       <p>The AggregateError constructor:</p>
       <ul>
-        <li>is the intrinsic object <dfn>%AggregateError%</dfn></li>
+        <li>is the intrinsic object <dfn>%AggregateError%</dfn>.</li>
         <li>is the initial value of the `AggregateError` property of the global object.</li>
-        <li>creates and initializes a new AggregateError object when called as a function rather than as a constructor. Thus the function call `AggregateError(...)` is equivalent to the object creation expression `new AggregateError(...)` with the same arguments.</li>
-        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `AggregateError` behaviour must include a `super` call to the `AggregateError` constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+        <li>creates and initializes a new AggregateError object when called as a function rather than as a constructor. Thus the function call `AggregateError(&hellip;)` is equivalent to the object creation expression `new AggregateError(&hellip;)` with the same arguments.</li>
+        <li>is designed to be subclassable. It may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified AggregateError behaviour must include a `super` call to the AggregateError constructor to create and initialize subclass instances with an [[ErrorData]] and [[AggregateErrors]] internal slots.</li>
       </ul>
+
       <emu-clause id="sec-aggregateerror-errors-message">
         <h1>AggregateError ( _errors_, _message_ )</h1>
         <p>When the *AggregateError* function is called with arguments _errors_ and _message_, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
-          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%AggregateErrorPrototype%"`, &laquo; [[ErrorData]] &raquo;).
+          1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, `"%AggregateError.prototype%"`, &laquo; [[ErrorData]], [[AggregateErrors]] &raquo;).
           1. Let _errorsIterator_ be ? GetMethod(_errors_, @@iterator).
           1. Let _errorsList_ be ? IterableToList(_errors_, _errorsIterator_).
-          1. Let _errorsArray_ be ! CreateArrayFromList(_errorsList_).
-          1. Perform ! CreateDataProperty(_O_, `"errors"`, _errorsArray_).
+          1. Set _O_.[[AggregateErrors]] to _errorsList_.
           1. If _message_ is not *undefined*, then
             1. Let _msg_ be ? ToString(_message_).
             1. Let _msgDesc_ be the PropertyDescriptor { [[Value]]: _msg_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
@@ -31,6 +32,7 @@
         </emu-alg>
       </emu-clause>
     </emu-clause>
+
     <emu-clause id="sec-properties-of-the-aggregateerror-constructor">
       <h1>Properties of the AggregateError Constructor</h1>
       <p>The AggregateError constructor:</p>
@@ -38,40 +40,53 @@
         <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.</li>
         <li>has the following properties:</li>
       </ul>
+
       <emu-clause id="sec-aggregateerror-prototype">
         <h1>AggregateError.prototype</h1>
-        <p>The intial value of `AggregateError.prototype` is the intrinsic object <dfn>%AggregateErrorPrototype%</dfn>.</p>
+        <p>The initial value of `AggregateError.prototype` is the intrinsic object %AggregateError.prototype%.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>
+
     <emu-clause id="sec-properties-of-the-aggregateerror-prototype-object">
       <h1>Properties of the AggregateError Prototype Object</h1>
       <p>The AggregateError prototype object:</p>
       <ul>
+        <li>is the intrinsic object <dfn>%AggregateError.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
-        <li>is not an Error instance and does not have an [[ErrorData]] internal slot.</li>
-        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %ErrorPrototype%.</li>
+        <li>is not an AggregateError instance and does not have an [[ErrorData]] or [[AggregateErrors]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is the intrinsic object %Error.prototype%.</li>
       </ul>
+
       <emu-clause id="sec-aggregateerror.prototype.constructor">
         <h1>AggregateError.prototype.constructor</h1>
-        <p>The initial value of `AggregateError.prototype.constructor` is the intrinsic %AggregateError% object.</p>
+        <p>The initial value of `AggregateError.prototype.constructor` is the intrinsic object %AggregateError%.</p>
       </emu-clause>
+
       <emu-clause id="sec-aggregateerror.prototype.message">
         <h1>AggregateError.prototype.message</h1>
         <p>The initial value of `AggregateError.prototype.message` is the empty String.</p>
       </emu-clause>
+
       <emu-clause id="sec-aggregateerror.prototype.name">
         <h1>AggregateError.prototype.name</h1>
         <p>The initial value of `AggregateError.prototype.name` is `"AggregateError"`.</p>
       </emu-clause>
-      <emu-clause id="sec-aggregateerror.prototype.errors">
-        <h1>AggregateError.prototype.errors</h1>
-        <p>The initial value of `AggregateError.prototype.errors` is *undefined*.</p>
+
+      <emu-clause id="sec-aggregate-error.prototype.errors">
+        <h1>get AggregateError.prototype.errors</h1>
+        <p>`AggregateError.prototype.errors` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+        <emu-alg>
+          1. Let _E_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_E_, [[AggregateErrors]]).
+          1. Assert: _E_ has an [[ErrorData]] internal slot.
+          1. Return ! CreateArrayFromList(_E_.[[AggregateErrors]]).
+        </emu-alg>
       </emu-clause>
     </emu-clause>
     <emu-clause id="sec-properties-of-aggregateerror-instances">
       <h1>Properties of AggregateError Instances</h1>
-      <p>AggregateError instances are ordinary objects that inherit properties from the AggregateError prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified uses of [[ErrorData]] is to identify Error, AggregateError, and _NativeError_ instances as Error objects within `Object.prototype.toString`.</p>
+      <p>AggregateError instances are ordinary objects that inherit properties from the AggregateError prototype object and have an [[AggregateErrors]] internal slot and an [[ErrorData]] internal slot whose value is *undefined*. The only specified uses of [[ErrorData]] is to identify Error, AggregateError, and _NativeError_ instances as Error objects within `Object.prototype.toString`.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/sec-well-known-intrinsic-objects-patch.html
+++ b/spec/sec-well-known-intrinsic-objects-patch.html
@@ -33,7 +33,7 @@
           <ins>`AggregateError.prototype`</ins>
         </td>
         <td>
-          <ins>The initial value of the `prototype` data property of %AggregateError%</ins>
+          <ins>The initial value of the `prototype` data property of %AggregateError%; i.e., %AggregateError.prototype%</ins>
         </td>
       </tr>
       </tbody>


### PR DESCRIPTION
This matches [the `Promise.any` proposal’s `AggregateError`](https://tc39.es/proposal-promise-any/#sec-aggregate-error-objects) and [the polyfill](https://github.com/es-shims/AggregateError).

## See also:
- <https://github.com/tc39/proposal-promise-any/pull/63>