### PR TITLE
Reduce proposal scope to only RAII-style 'using' declarations

### DIFF
--- a/future/using-await-declaration.md
+++ b/future/using-await-declaration.md
@@ -1,0 +1,166 @@
+# `using await` Declarations for ECMAScript
+
+A `using await` declaration is a variation of the [`using` declaration](../README.md) that is designed to work with
+Async Disposable objects, which allow async logic to be evaluated and awaited during disposal. A `using await`
+declaration is only permitted in an `[+Await]` context such as the top level of a _Module_ or inside the body of an
+async function.
+
+# Example
+
+```js
+class Logger {
+  write(message) { ... }
+  ...
+  #disposed = false;
+  async [Symbol.asyncDispose]() {
+    if (!this.#disposed) {
+      this.#disposed = true;
+      await this.#flush(); // flush any pending log file writes asynchronously.
+      this.#close(); // close file handle.
+    }
+  }
+}
+
+async function main() {
+  using await logger = new Logger(); // create logger, async dispose at end of block
+  logger.write("started");
+  ...
+  logger.write("done");
+
+  // implicit `await logger[Symbol.asyncDispose]()` when block exits regardless as to
+  // whether by `return`, `throw`, `break`, or `continue`.
+}
+```
+
+# Status
+
+**Status:** Out of scope
+
+The `using await` declaration has been postponed and deemed out of scope for the original proposal. This is primarily
+due to concerns about introducing an implicit `await` without a clear marker at the start or end of the containing
+block.
+
+# Alternatives
+
+This could also potentially be addressed by the [`using await` statement](./using-await-statement.md).
+
+# Postponement Implications
+
+Postponing `using await` declarations without also introducing `using await` statements means that we lose the ability
+to declaratively register disposal of resources that require async cleanup steps. This affects use cases such as
+three-phase commit (3PC) transactions and some async file I/O (i.e., async flush). These still can be accomplished
+imperatively via `await obj[Symbol.asyncDispose]()`, but the lack of a syntactic declaration reduces their utility.
+
+# Explainer Snapshot
+
+The following sections were originally part of the [explainer](../README.md).
+
+> # Syntax
+>
+> ## `using` Declarations
+>
+> ```js
+> // for an asynchronously-disposed resource (block scoped):
+> using await x = expr1;                          // resource w/ local binding
+> using await void = expr;                        // resource w/o local binding
+> using await y = expr2, void = expr3, z = expr3; // multiple resources
+> ```
+>
+> # Grammar
+>
+> ```grammarkdown
+> UsingDeclaration[In, Yield, Await] :
+>     ...
+>     [+Await] `using` [no LineTerminator here] `await` BindingList[?In, ?Yield, +Await, +Using] `;`
+> ```
+>
+> # Semantics
+>
+> ## `using` Declarations
+>
+> ### `using await` Declarations and Values Without `[Symbol.asyncDispose]`
+>
+> If a resource does not have either a callable `[Symbol.asyncDispose]` member or a callable  `[Symbol.dispose]` member,
+> a `TypeError` would be thrown **immediately** when the resource is tracked.
+>
+> ### `using await` Declarations in _AsyncFunction_, _AsyncGeneratorFunction_, or _Module_
+>
+> In an _AsyncFunction_, _AsyncGeneratorFunction_, _AsyncArrowFunction_, or the top-level of a _Module_, when we
+> evaluate a `using await` declaration we first look for a `[Symbol.asyncDispose]` method before looking for a
+> `[Symbol.dispose]` method. At the end of the containing function body, _Block_, or _Module_, if the method returns a
+> value other than `undefined`, we **Await** the value before exiting:
+>
+> ```js
+> async function f() {
+>   ... // (1)
+>   using await x = expr;
+>   ... // (2)
+> }
+> ```
+>
+> Is semantically equivalent to the following transposed representation:
+>
+>
+> ```js
+> async function f() {
+>   const $$try = { stack: [], exception: undefined };
+>   try {
+>     ... // (1)
+>
+>     const x = expr;
+>     if (x !== null && x !== undefined) {
+>       let $$dispose = x[Symbol.asyncDispose];
+>       if ($$dispose === undefined) {
+>         $$dispose = x[Symbol.dispose];
+>       }
+>       if (typeof $$dispose !== "function") {
+>         throw new TypeError();
+>       }
+>       $$try.stack.push({ value: x, dispose: $$dispose });
+>     }
+>
+>     ... // (2)
+>   }
+>   catch ($$error) {
+>     $$try.exception = { cause: $$error };
+>   }
+>   finally {
+>     const $$errors = [];
+>     while ($$try.stack.length) {
+>       const { value: $$expr, dispose: $$dispose } = $$try.stack.pop();
+>       try {
+>         const $$result = $$dispose.call($$expr);
+>         if ($$result !== undefined) {
+>           await $$result;
+>         }
+>       }
+>       catch ($$error) {
+>         $$errors.push($$error);
+>       }
+>     }
+>     if ($$errors.length > 0) {
+>       throw new AggregateError($$errors, undefined, $$try.exception);
+>     }
+>     if ($$try.exception) {
+>       throw $$try.exception.cause;
+>     }
+>   }
+> }
+> ```
+>
+> # Examples
+>
+> The following show examples of using this proposal with various APIs, assuming those APIs adopted this proposal.
+>
+> ### Transactional Consistency (ACID/3PC)
+> ```js
+> // roll back transaction if either action fails
+> {
+>   using await tx = transactionManager.startTransaction(account1, account2);
+>   await account1.debit(amount);
+>   await account2.credit(amount);
+> 
+>   // mark transaction success
+>   tx.succeeded = true;
+> } // transaction is committed
+> ```

--- a/future/using-await-statement.md
+++ b/future/using-await-statement.md
@@ -1,0 +1,58 @@
+# `using await` Statements for ECMAScript
+
+A `using await` statement is a variation of the [`using` statement](./using-statement.md) that is designed to work with
+Async Disposable objects, which allow async logic to be evaluated and awaited during disposal. A `using await`
+statement is only permitted in an `[+Await]` context such as the top level of a _Module_ or inside the body of an
+async function.
+
+# Example
+
+```js
+class Logger {
+  write(message) { ... }
+  ...
+  #disposed = false;
+  async [Symbol.asyncDispose]() {
+    if (!this.#disposed) {
+      this.#disposed = true;
+      await this.#flush(); // flush any pending log file writes asynchronously.
+      this.#close(); // close file handle.
+    }
+  }
+}
+
+async function main() {
+  using await (logger = new Logger()) { // create logger, async dispose at end of block
+    logger.write("started");
+    ...
+    logger.write("done");
+
+    // implicit `await logger[Symbol.asyncDispose]()` when block exits regardless as to
+    // whether by `return`, `throw`, `break`, or `continue`.
+  }
+}
+```
+
+# Status
+
+**Status:** Out of scope
+
+The `using await` statement has been postponed and deemed out of scope for the original proposal. This was cut primarily
+to reduce the scope of the intial proposal, but also due to the inconsistency between the RAII-style
+[`using` declaration](../README.md) and the block-style of the `using await` statement that exists now that the
+block-style [`using` statement](./using-statement.md) is also out of scope.
+
+# Alternatives
+
+This could also potentially be addressed by the [`using await` declaration](./using-await-declaration.md).
+
+# Postponement Implications
+
+Postponing `using await` statements without also introducing `using await` declarations means that we lose the ability
+to declaratively register disposal of resources that require async cleanup steps. This affects use cases such as
+three-phase commit (3PC) transactions and some async file I/O (i.e., async flush). These still can be accomplished
+imperatively via `await obj[Symbol.asyncDispose]()`, but the lack of a syntactic declaration reduces their utility.
+
+# More Information
+
+An early draft of the spec text for `using await` statements can be found in #86.

--- a/future/using-statement.md
+++ b/future/using-statement.md
@@ -1,0 +1,68 @@
+# `using` Statements for ECMAScript
+
+A `using` statement is a block-style variation of the RAII-style [`using` declaration](../README.md).
+
+# Example
+
+```js
+// introducing a binding
+using (res = expr) { // evaluate 'expr' and bind to 'res', which is disposed at the end of the block
+  ...
+
+} // 'res' is disposed (calls 'res[Symbol.dispose]()')
+
+
+// multiple bindings
+using (res1 = expr1, res2 = expr2) {
+    ...
+} // res2 is disposed, then res1 is disposed
+
+
+// no binding
+using (void = expr1) { // evaluate 'expr1' and store result in implicit variable
+
+} // implicit variable is disposed
+```
+
+# Status
+
+**Status:** Out of scope
+
+The `using` statement has been postponed and deemed out of scope for the original proposal. This was cut primarily
+to reduce the scope of the intial proposal and to focus on the highly preferred RAII-style.
+
+# Alternatives
+
+This could also potentially be addressed by the [`using await` declaration](./using-await-declaration.md).
+
+# Postponement Implications
+
+Though the `using` statement provided a bridge between RAII-style [`using` declarations](../README.md) and the
+block-style [`using await` statement](./using-await-statement.md). Postponing the `using` statement may decrease the
+likelihood that the `using await` statement could advance in a version of ECMAScript that already had `using`
+declarations.
+
+# History
+
+The initial draft of this proposal used the `using` statement syntax, as well as the following alternatives, before the
+proposal settled on the RAII-style `using` declaration form:
+
+```js
+// initial draft
+using (const res = expr) { ... }
+
+// Java try-with-resources variant
+try (const res = expr) { ... }
+try (const res = expr) { ... } finally { }
+
+// other variations
+try using (const res = expr) { ... }
+try using (const res = expr) { ... } finally { }
+
+// final version
+using (res = expr) { ... }
+```
+
+# More Information
+
+An early draft of the spec text for `using` statements can be found in #86.

--- a/future/using-void-declaration.md
+++ b/future/using-void-declaration.md
@@ -1,0 +1,213 @@
+# `using void` Declarations for ECMAScript
+
+A `using void` declaration is a bindingless variant of the RAII-style [`using` declaration](../README.md). With this
+form, a `void` keyword may be substituted in place of a _BindingIdentifier_. In this case, a user-accessible
+block-scoped binding is not created for the result of the expression, but that result may still participate in
+disposal at the end of the block.
+
+The `using void` variant was also present in the [`using` statement](./using-statement.md),
+[`using await` statement](./using-await-statement.md), and [`using await` declaration](./using-await-declaration.md)
+proposals, which are now also out of scope.
+
+# Example
+
+```js
+// block-scoped resource, no binding
+{
+    using void = expr1; // 'expr1' is evaluated and result is captured until the end of the block.
+    ...
+} // result is disposed
+
+
+// multiple bindingless resources
+{
+    using void = expr1, void = expr2;
+    ...
+} // result of expr2 is disposed, then result of expr1 is disposed
+
+
+// mixing bindings and bindingless forms
+{
+    using x = expr1, void = expr2, y = expr3;
+
+} // y is disposed, then result of expr2 is disposed, then x is disposed
+
+
+// in a 'using' statement
+using (void = expr1) { ... }
+
+
+// in a 'using await' statement
+using await (void = expr1) { ... }
+
+
+// in a `using await` declaration
+{
+    using await void = expr1;
+    ...
+} // result of expr1 is asynchronously disposed
+```
+
+# Status
+
+**Status:** Out of scope
+
+The `using void` declaration has been postponed and deemed out of scope for the original proposal. This was cut
+primarily to reduce the scope of the intial proposal, though we believe a bindingless form would still be invaluable
+for many use cases such as locking, logging, etc.:
+
+```js
+// locking a resource
+function useResource() {
+  // NOTE: `mutex.lock()` blocks the thread until it can take a lock, returning a lock handle object with a
+  // `[Symbol.dispose]` method that releases the lock at the end of the block.
+
+  using void = mutex.lock(); // binding would be unused, potentially causing linters to complain.
+
+  res.doSomething();
+
+} // The lock handle object is disposed.
+
+
+// activity logging
+class Activity {
+    #name;
+    #start;
+    #disposed = false;
+    constructor(name) {
+        this.#name = name;
+        this.#start = Date.now();
+        console.log(`Activity '${name}' started.`);
+    }
+
+    [Symbol.dispose]() {
+        if (!this.#disposed) {
+            this.#disposd = true;
+            const end = Date.now();
+            console.log(`Activity '${name}' ended. Took ${end - start} ms.`);
+        }
+    }
+}
+
+function operation1() {
+    using void = new Activity("operation1");
+    operation2();
+}
+
+function operation2() {
+    using void = new Activity("operation2");
+    console.log("some long running operation...");
+}
+
+operation1();
+// Logs:
+//   Activity 'operation1' started.
+//   Activity 'operation2' started.
+//   some long running operation...
+//   Activity 'operation2' ended. Took ? ms.
+//   Activity 'operation1' ended. Took ? ms.
+```
+
+# Alternatives
+
+There is no currently proposed alternative that avoids introducing an unnecessary binding. In these cases, its likely
+that users will do something like:
+
+```js
+using _ = expr;
+```
+
+or
+
+```js
+using dummy = expr; // eslint-disable-line no-unused-vars
+```
+
+# Postponement Implications
+
+The `using void` declaration is more of a "nice to have" feature to avoid needing to name otherwise unreferenced
+resources, where the side-effects of the `[Symbol.dispose]` method invoked at the end of the block are desired, or
+when the desire is to leverage an effect similar to Go's `defer`.
+
+# More Information
+
+An early draft of the spec text supporting `using void` declarations can be found in #86.
+
+# Explainer Snapshot
+
+The following sections were originally part of the [explainer](../README.md).
+
+> # Semantics
+>
+> ## `using` Declarations
+>
+> ### `using` Declarations with Existing Resources
+>
+> ```grammarkdown
+> UsingDeclaration :
+>     `using` BindingList `;`
+>     `using` `await` BindingList `;`
+>
+> LexicalBinding :
+>     `void` Initializer
+> ```
+>
+> When a `using` declaration is parsed with `void` _Initializer_, an implicit block-scoped binding is created for the
+> result of the expression. When the _Block_ or _Module_ immediately containing the `using` declaration is exited,
+> whether by an abrupt or normal completion, `[Symbol.dispose]()` is called on the implicit binding as long as it is
+> neither `null` nor `undefined`. If an error is thrown in both the containing _Block_/_Module_ and the call to
+> `[Symbol.dispose]()`, an `AggregateError` containing both errors will be thrown instead.
+>
+> ```js
+> {
+>   ... // (1)
+>   using void = expr; // in Block scope
+>   ... // (2)
+> }
+> ```
+>
+> The above example has similar runtime semantics as the following transposed representation:
+>
+> ```js
+> {
+>   const $$try = { stack: [], exception: undefined };
+>   try {
+>     ... // (1)
+>
+>     const $$expr = expr; // evaluate `expr`
+>     if ($$expr !== null && $$expr !== undefined) {
+>       const $$dispose = $$expr[Symbol.dispose];
+>       if (typeof $$dispose !== "function") {
+>         throw new TypeError();
+>       }
+>       $$try.stack.push({ value: $$expr, dispose: $$dispose });
+>     }
+>
+>     ... // (2)
+>   }
+>   catch ($$error) {
+>     $$try.exception = { cause: $$error };
+>   }
+>   finally {
+>     const $$errors = [];
+>     while ($$try.stack.length) {
+>       const { value: $$expr, dispose: $$dispose } = $$try.stack.pop();
+>       try {
+>         $$dispose.call($$expr);
+>       }
+>       catch ($$error) {
+>         $$errors.push($$error);
+>       }
+>     }
+>     if ($$errors.length > 0) {
+>       throw new AggregateError($$errors, undefined, $$try.exception);
+>     }
+>     if ($$try.exception) {
+>       throw $$try.exception.cause;
+>     }
+>   }
+> }
+> ```
+>
+> The local block-scoped binding ensures that if `expr` above is reassigned, we still correctly close the resource we are
+> explicitly tracking.

--- a/spec.emu
+++ b/spec.emu
@@ -166,7 +166,7 @@ contributors: Ron Buckton, Ecma International
                 <ins>`"Symbol.asyncDispose"`</ins>
               </td>
               <td>
-                <ins>A method that performs explicit resource cleanup on an object. Called by the semantics of the `using await` declaration while in an async function, async generator, or the top level of a _Module_.</ins>
+                <ins>A method that performs explicit resource cleanup on an object. Called by the semantics of AsyncDisposableStack objects.</ins>
               </td>
             </tr>
             <tr>
@@ -177,7 +177,7 @@ contributors: Ron Buckton, Ecma International
                 <ins>`"Symbol.dispose"`</ins>
               </td>
               <td>
-                <ins>A method that performs explicit resource cleanup on an object. Called by the semantics of the `using` declaration.</ins>
+                <ins>A method that performs explicit resource cleanup on an object. Called by the semantics of the `using` declaration and DisposableStack objects.</ins>
               </td>
             </tr>
             </tbody>
@@ -260,7 +260,7 @@ contributors: Ron Buckton, Ecma International
               ~sync-dispose~ or ~async-dispose~.
             </td>
             <td>
-              Indicates whether the resources was added by a `using` declaration (~sync-dispose~) or a `using await` declaration (~async-dispose~).
+              Indicates whether the resources was added by a `using` declaration or DisposableStack object (~sync-dispose~) or an AsyncDisposableStack object (~async-dispose~).
             </td>
           </tr>
           <tr>
@@ -427,7 +427,6 @@ contributors: Ron Buckton, Ecma International
       <emu-grammar>
         UsingDeclaration :
           `using` BindingList `;`
-          `using` `await` BindingList `;`
       </emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingList|.
@@ -447,12 +446,6 @@ contributors: Ron Buckton, Ecma International
       <emu-alg>
         1. Return the BoundNames of |BindingPattern|.
       </emu-alg>
-      <ins class="block">
-      <emu-grammar>LexicalBinding : `void` Initializer</emu-grammar>
-      <emu-alg>
-        1. Return a new empty List.
-      </emu-alg>
-      </ins>
       <emu-grammar>VariableDeclarationList : VariableDeclarationList `,` VariableDeclaration</emu-grammar>
       <emu-alg>
         1. Let _names1_ be BoundNames of |VariableDeclarationList|.
@@ -966,7 +959,7 @@ contributors: Ron Buckton, Ecma International
               InitializeBinding(N, V<ins>, _hint_</ins>)
             </td>
             <td>
-              Set the value of an already existing but uninitialized binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and is a value of any ECMAScript language type. <ins>_hint_ indicates whether the binding came from a `using` declaration (~sync-dispose~), a `using await` declaration (~async-dispose~), or a regular variable declaration (~normal~).</ins>
+              Set the value of an already existing but uninitialized binding in an Environment Record. The String value _N_ is the text of the bound name. _V_ is the value for the binding and is a value of any ECMAScript language type. <ins>_hint_ indicates whether the binding came from either a `using` declaration (~sync-dispose~) or a regular variable declaration (~normal~).</ins>
             </td>
           </tr>
           <tr>
@@ -1024,7 +1017,7 @@ contributors: Ron Buckton, Ecma International
       <emu-clause id="sec-declarative-environment-records">
         <h1>Declarative Environment Records</h1>
         <p>Each <dfn>declarative Environment Record</dfn> is associated with an ECMAScript program scope containing variable, constant, let, class, module, import, and/or function declarations. A declarative Environment Record binds the set of identifiers defined by the declarations contained within its scope.</p>
-        <p><ins>Every declarative Environment Record also has a [[DisposableResourceStack]] field, which is a List of DisposableResource Records. This list is a stack of resources tracked by the `using` and `using await` declarations that must be disposed when the Evaluation step that constructed the Environment Record has completed.</ins></p>
+        <p><ins>Every declarative Environment Record also has a [[DisposableResourceStack]] field, which is a List of DisposableResource Records. This list is a stack of resources tracked by the `using` declarations that must be disposed when the Evaluation step that constructed the Environment Record has completed.</ins></p>
         <p>The behaviour of the concrete specification methods for declarative Environment Records is defined by the following algorithms.</p>
 
         <emu-clause id="sec-declarative-environment-records-initializebinding-n-v" type="concrete method">
@@ -1032,7 +1025,7 @@ contributors: Ron Buckton, Ecma International
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-              <ins>_hint_: either ~normal~, ~sync-dispose~, or ~async-dispose~,</ins>
+              <ins>_hint_: either ~normal~ or ~sync-dispose~,</ins>
             ): a normal completion containing ~unused~
           </h1>
           <dl class="header">
@@ -1060,7 +1053,7 @@ contributors: Ron Buckton, Ecma International
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-              <ins>_hint_: either ~normal~, ~sync-dispose~, or ~async-dispose~,</ins>
+              <ins>_hint_: either ~normal~ or ~sync-dispose~,</ins>
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -1090,7 +1083,7 @@ contributors: Ron Buckton, Ecma International
             InitializeBinding (
               _N_: a String,
               _V_: an ECMAScript language value,
-              <ins>_hint_: either ~normal~, ~sync-dispose~, or ~async-dispose~,</ins>
+              <ins>_hint_: either ~normal~ or ~sync-dispose~,</ins>
             ): either a normal completion containing ~unused~ or a throw completion
           </h1>
           <dl class="header">
@@ -1157,7 +1150,6 @@ contributors: Ron Buckton, Ecma International
         <ins>
         UsingDeclaration[In, Yield, Await] :
           `using` [no LineTerminator here] BindingList[?In, ?Yield, ?Await, +Using] `;`
-          [+Await] `using` [no LineTerminator here] `await` BindingList[?In, ?Yield, +Await, +Using] `;`
         </ins>
 
         BindingList[In, Yield, Await, <ins>Using</ins>] :
@@ -1168,7 +1160,6 @@ contributors: Ron Buckton, Ecma International
           BindingIdentifier[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]?
           <del>BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]</del>
           <ins>[~Using] BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]</ins>
-          <ins>[+Using] `void` Initializer[?In, ?Yield, ?Await]</ins>
       </emu-grammar>
 
       <emu-clause id="sec-let-and-const-declarations-static-semantics-early-errors">
@@ -1177,7 +1168,6 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>
           UsingDeclaration :
             `using` BindingList `;`
-            `using` `await` BindingList `;`
         </emu-grammar>
         <ul>
           <li>
@@ -1217,12 +1207,6 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>UsingDeclaration : `using` BindingList `;`</emu-grammar>
         <emu-alg>
           1. Let _next_ be BindingEvaluation of |BindingList| with parameter ~sync-dispose~.
-          1. ReturnIfAbrupt(_next_).
-          1. Return ~empty~.
-        </emu-alg>
-        <emu-grammar>UsingDeclaration : `using` `await` BindingList `;`</emu-grammar>
-        <emu-alg>
-          1. Let _next_ be BindingEvaluation of |BindingList| with parameter ~async-dispose~.
           1. ReturnIfAbrupt(_next_).
           1. Return ~empty~.
         </emu-alg>
@@ -1270,7 +1254,7 @@ contributors: Ron Buckton, Ecma International
       <emu-clause id="sec-let-and-const-declarations-runtime-semantics-bindingevaluation" type="sdo">
         <h1>
           Runtime Semantics: BindingEvaluation (
-            _hint_: either ~normal~, ~sync-dispose~, or ~async-dispose~
+            _hint_: either ~normal~ or ~sync-dispose~
           ): either a normal completion containing ~unused~ or an abrupt completion
         </h1>
         <dl class="header">
@@ -1308,14 +1292,6 @@ contributors: Ron Buckton, Ecma International
           1. Let _value_ be ? GetValue(_rhs_).
           1. Let _env_ be the running execution context's LexicalEnvironment.
           1. Return ? BindingInitialization of |BindingPattern| with arguments _value_ and _env_.
-        </emu-alg>
-        <emu-grammar>LexicalBinding : `void` Initializer</emu-grammar>
-        <emu-alg>
-          1. Assert: _hint_ is ~sync-dispose~ or ~async-dispose~.
-          1. Let _expr_ be the result of evaluating |Initializer|.
-          1. Let _value_ be ? GetValue(_expr_).
-          1. Let _env_ be the running execution context's LexicalEnvironment.
-          1. Return ? AddDisposableResource(_env_, _value_, _hint_).
         </emu-alg>
       </emu-clause>
       </ins>
@@ -1515,7 +1491,6 @@ contributors: Ron Buckton, Ecma International
         ForDeclaration[Yield, Await, <ins>Using</ins>] :
           LetOrConst ForBinding[?Yield, ?Await, <ins>~Using</ins>]
           <ins>[+Using] `using` [no LineTerminator here] ForBinding[?Yield, ?Await, +Using]</ins>
-          <ins>[+Using, +Await] `using` [no LineTerminator here] `await` ForBinding[?Yield, ?Await, +Using]</ins>
 
         ForBinding[Yield, Await, <ins>Using</ins>] :
           BindingIdentifier[?Yield, ?Await]
@@ -1741,7 +1716,7 @@ contributors: Ron Buckton, Ecma International
       </emu-note>
       <ins class="block">
       <emu-note>
-        <p>A `using` or `using await` declaration that precedes a call in the same |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody| prevents that call from being a possible tail position call.</p>
+        <p>A `using` declaration that precedes a call in the same |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody| prevents that call from being a possible tail position call.</p>
       </emu-note>
       </ins>
 
@@ -1891,195 +1866,6 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>Catch : `catch` `(` CatchParameter `)` Block</emu-grammar>
         <emu-alg>
           1. Return HasCallInTailPosition of |Block| with argument _call_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-expression-rules">
-        <h1>Expression Rules</h1>
-        <emu-note>
-          <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. A function call cannot return a Reference Record, so such a GetValue operation will always return the same value as the actual function call result.</p>
-        </emu-note>
-        <emu-grammar>
-          AssignmentExpression :
-            YieldExpression
-            ArrowFunction
-            AsyncArrowFunction
-            LeftHandSideExpression `=` AssignmentExpression
-            LeftHandSideExpression AssignmentOperator AssignmentExpression
-            LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
-            LeftHandSideExpression `||=` AssignmentExpression
-            LeftHandSideExpression `??=` AssignmentExpression
-
-          BitwiseANDExpression : BitwiseANDExpression `&amp;` EqualityExpression
-
-          BitwiseXORExpression : BitwiseXORExpression `^` BitwiseANDExpression
-
-          BitwiseORExpression : BitwiseORExpression `|` BitwiseXORExpression
-
-          EqualityExpression :
-            EqualityExpression `==` RelationalExpression
-            EqualityExpression `!=` RelationalExpression
-            EqualityExpression `===` RelationalExpression
-            EqualityExpression `!==` RelationalExpression
-
-          RelationalExpression :
-            RelationalExpression `&lt;` ShiftExpression
-            RelationalExpression `&gt;` ShiftExpression
-            RelationalExpression `&lt;=` ShiftExpression
-            RelationalExpression `&gt;=` ShiftExpression
-            RelationalExpression `instanceof` ShiftExpression
-            RelationalExpression `in` ShiftExpression
-            PrivateIdentifier `in` ShiftExpression
-
-          ShiftExpression :
-            ShiftExpression `&lt;&lt;` AdditiveExpression
-            ShiftExpression `&gt;&gt;` AdditiveExpression
-            ShiftExpression `&gt;&gt;&gt;` AdditiveExpression
-
-          AdditiveExpression :
-            AdditiveExpression `+` MultiplicativeExpression
-            AdditiveExpression `-` MultiplicativeExpression
-
-          MultiplicativeExpression :
-            MultiplicativeExpression MultiplicativeOperator ExponentiationExpression
-
-          ExponentiationExpression :
-            UpdateExpression `**` ExponentiationExpression
-
-          UpdateExpression :
-            LeftHandSideExpression `++`
-            LeftHandSideExpression `--`
-            `++` UnaryExpression
-            `--` UnaryExpression
-
-          UnaryExpression :
-            `delete` UnaryExpression
-            `void` UnaryExpression
-            `typeof` UnaryExpression
-            `+` UnaryExpression
-            `-` UnaryExpression
-            `~` UnaryExpression
-            `!` UnaryExpression
-            AwaitExpression
-
-          CallExpression :
-            SuperCall
-            CallExpression `[` Expression `]`
-            CallExpression `.` IdentifierName
-            CallExpression `.` PrivateIdentifier
-
-          NewExpression : `new` NewExpression
-
-          MemberExpression :
-            MemberExpression `[` Expression `]`
-            MemberExpression `.` IdentifierName
-            SuperProperty
-            MetaProperty
-            `new` MemberExpression Arguments
-            MemberExpression `.` PrivateIdentifier
-
-          PrimaryExpression :
-            `this`
-            IdentifierReference
-            Literal
-            ArrayLiteral
-            ObjectLiteral
-            FunctionExpression
-            ClassExpression
-            GeneratorExpression
-            AsyncFunctionExpression
-            AsyncGeneratorExpression
-            RegularExpressionLiteral
-            TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          Expression :
-            AssignmentExpression
-            Expression `,` AssignmentExpression
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |AssignmentExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>ConditionalExpression : ShortCircuitExpression `?` AssignmentExpression `:` AssignmentExpression</emu-grammar>
-        <emu-alg>
-          1. Let _has_ be HasCallInTailPosition of the first |AssignmentExpression| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. Return HasCallInTailPosition of the second |AssignmentExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>LogicalANDExpression : LogicalANDExpression `&amp;&amp;` BitwiseORExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>LogicalORExpression : LogicalORExpression `||` LogicalANDExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |LogicalANDExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>CoalesceExpression : CoalesceExpressionHead `??` BitwiseORExpression</emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |BitwiseORExpression| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          CallExpression :
-            CoverCallExpressionAndAsyncArrowHead
-            CallExpression Arguments
-            CallExpression TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. If this |CallExpression| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          OptionalExpression :
-            MemberExpression OptionalChain
-            CallExpression OptionalChain
-            OptionalExpression OptionalChain
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |OptionalChain| with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          OptionalChain :
-            `?.` `[` Expression `]`
-            `?.` IdentifierName
-            `?.` PrivateIdentifier
-            OptionalChain `[` Expression `]`
-            OptionalChain `.` IdentifierName
-            OptionalChain `.` PrivateIdentifier
-        </emu-grammar>
-        <emu-alg>
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          OptionalChain :
-            `?.` Arguments
-            OptionalChain Arguments
-        </emu-grammar>
-        <emu-alg>
-          1. If this |OptionalChain| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>
-          MemberExpression :
-            MemberExpression TemplateLiteral
-        </emu-grammar>
-        <emu-alg>
-          1. If this |MemberExpression| is _call_, return *true*.
-          1. Return *false*.
-        </emu-alg>
-        <emu-grammar>PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList</emu-grammar>
-        <emu-alg>
-          1. Let _expr_ be the |ParenthesizedExpression| that is covered by |CoverParenthesizedExpressionAndArrowParameterList|.
-          1. Return HasCallInTailPosition of _expr_ with argument _call_.
-        </emu-alg>
-        <emu-grammar>
-          ParenthesizedExpression :
-            `(` Expression `)`
-        </emu-grammar>
-        <emu-alg>
-          1. Return HasCallInTailPosition of |Expression| with argument _call_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -2348,7 +2134,6 @@ contributors: Ron Buckton, Ecma International
               <td>
                 <p>Invoking this method notifies the <em>AsyncDisposable</em> object that the caller does not intend to continue to use this object. This method should perform any necessary logic to perform explicit clean-up of the resource including, but not limited to, file system handles, streams, host objects, etc. When an exception is thrown from this method, it typically means that the resource could not be explicitly freed. An <em>AsyncDisposable</em> object is not considered "disposed" until the resulting Promise has been fulfilled.</p>
                 <p>If called more than once on the same object, the function should not throw an exception. However, this requirement is not enforced.</p>
-                <p>When using an <em>AsyncDisposable</em> object, it is good practice to create the instance with a `using await` declaration, as the resource will be automatically disposed when the |Block| or |Module| containing the declaration has been evaluated.</p>
               </td>
             </tr>
             </tbody>


### PR DESCRIPTION
Following a [twitter conversation](https://twitter.com/littledan/status/1555619485905784833) with @littledan at the beginning of August, this PR reduces the scope of the Explicit Resource Management proposal to focus specifically on RAII-style `using` declarations.

As a result, the following features are now considered out of scope and would instead be addressed by follow-on proposals:
- Bindingless `using void` declarations.
- Block-style `using` statements.
- Block-style `using await` statements.
- RAII-style `using await` declarations.

Supersedes #86