### PR TITLE
Split 'use' overloads into multiple methods

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -3574,44 +3574,61 @@ contributors: Ron Buckton, Ecma International
       </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype.use">
-        <h1>DisposableStack.prototype.use( _value_ [, _onDispose_ ] )</h1>
-        <p>When the `use` function is called with one or two arguments, the following steps are taken:</p>
-        <emu-note>
-          <p>The _onDispose_ argument is optional. If it is not provided, *undefined* is used.</p>
-        </emu-note>
+        <h1>DisposableStack.prototype.use( _value_ )</h1>
+        <p>When the `use` function is called with one argument, the following steps are taken:</p>
         <emu-alg>
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If _onDispose_ is not *undefined*, then
-            1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
-            1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-disposablestack-callback-functions"></emu-xref>.
-            1. Set _F_.[[Argument]] to _value_.
-            1. Set _F_.[[OnDisposeCallback]] to _onDispose_.
-            1. Perform ? AddDisposableResource(_disposableStack_, *undefined*, ~sync-dispose~, _F_).
-          1. Else, if _value_ is neither *null* nor *undefined*, then
+          1. If _value_ is neither *null* nor *undefined*, then
             1. If Type(_value_) is not Object, throw a *TypeError* exception.
             1. Let _method_ be GetDisposeMethod(_value_, ~sync-dispose~).
             1. If _method_ is *undefined*, then
-              1. If IsCallable(_value_) is *true*, then
-                1. Perform ? AddDisposableResource(_disposableStack_, *undefined*, ~sync-dispose~, _value_).
-              1. Else,
                 1. Throw a *TypeError* exception.
             1. Else,
               1. Perform ? AddDisposableResource(_disposableStack_, _value_, ~sync-dispose~, _method_).
           1. Return _value_.
         </emu-alg>
+      </emu-clause>
 
-        <emu-clause id="sec-disposablestack-callback-functions">
-          <h1>DisposableStack Callback Functions</h1>
-          <p>A <dfn>DisposableStack callback function</dfn> is an anonymous built-in function object that has [[Argument]] and [[OnDisposeCallback]] internal slots.</p>
-          <p>When a DisposableStack callback function is called, the following steps are taken:</p>
+      <emu-clause id="sec-disposablestack.prototype.adopt">
+        <h1>DisposableStack.prototype.adopt( _value_, _onDispose_ )</h1>
+        <p>When the `adopt` function is called with two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _disposableStack_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
+          1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
+          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-disposablestack-adopt-callback-functions"></emu-xref>.
+          1. Set _F_.[[Argument]] to _value_.
+          1. Set _F_.[[OnDisposeCallback]] to _onDispose_.
+          1. Perform ? AddDisposableResource(_disposableStack_, *undefined*, ~sync-dispose~, _F_).
+          1. Return _value_.
+        </emu-alg>
+
+        <emu-clause id="sec-disposablestack-adopt-callback-functions">
+          <h1>DisposableStack Adopt Callback Functions</h1>
+          <p>A <dfn>DisposableStack adopt callback function</dfn> is an anonymous built-in function object that has [[Argument]] and [[OnDisposeCallback]] internal slots.</p>
+          <p>When a DisposableStack adopt callback function is called, the following steps are taken:</p>
           <emu-alg>
             1. Let _F_ be the active function object.
             1. Assert: IsCallable(_F_.[[OnDisposeCallback]]) is *true*.
             1. Return Call(_F_.[[OnDisposeCallback]], *undefined*, &laquo; _F_.[[Argument]] &raquo;).
           </emu-alg>
         </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-disposablestack.prototype.defer">
+        <h1>DisposableStack.prototype.defer( _onDispose_ )</h1>
+        <p>When the `defer` function is called with one argument, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _disposableStack_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
+          1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
+          1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
+          1. Perform ? AddDisposableResource(_disposableStack_, *undefined*, ~sync-dispose~, _onDispose_).
+          1. Return *undefined*.
+        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype.move">
@@ -3805,44 +3822,61 @@ contributors: Ron Buckton, Ecma International
       </emu-clause>
 
       <emu-clause id="sec-asyncdisposablestack.prototype.use">
-        <h1>AsyncDisposableStack.prototype.use( _value_ [, _onDisposeAsync_ ] )</h1>
-        <p>When the `use` function is called with one or two arguments, the following steps are taken:</p>
-        <emu-note>
-          <p>The _onDisposeAsync_ argument is optional. If it is not provided, *undefined* is used.</p>
-        </emu-note>
+        <h1>AsyncDisposableStack.prototype.use( _value_ )</h1>
+        <p>When the `use` function is called with one argument, the following steps are taken:</p>
         <emu-alg>
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. If _onDisposeAsync_ is not *undefined*, then
-            1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
-            1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-asyncdisposablestack-callback-functions"></emu-xref>.
-            1. Set _F_.[[Argument]] to _value_.
-            1. Set _F_.[[OnDisposeAsyncCallback]] to _onDisposeAsync_.
-            1. Perform ? AddDisposableResource(_asyncDisposableStack_, *undefined*, ~async-dispose~, _F_).
-          1. Else, if _value_ is neither *null* nor *undefined*, then
+          1. If _value_ is neither *null* nor *undefined*, then
             1. If Type(_value_) is not Object, throw a *TypeError* exception.
             1. Let _method_ be GetDisposeMethod(_value_, ~async-dispose~).
             1. If _method_ is *undefined*, then
-              1. If IsCallable(_value_) is *true*, then
-                1. Perform ? AddDisposableResource(_disposableStack_, *undefined*, ~async-dispose~, _value_).
-              1. Else,
                 1. Throw a *TypeError* exception.
             1. Else,
               1. Perform ? AddDisposableResource(_disposableStack_, _value_, ~async-dispose~, _method_).
           1. Return _value_.
         </emu-alg>
+      </emu-clause>
 
-        <emu-clause id="sec-asyncdisposablestack-callback-functions">
-          <h1>AsyncDisposableStack Callback Functions</h1>
-          <p>An AsyncDisposableStack callback function is an anonymous built-in function that has [[Argument]] and [[OnDisposeAsyncCallback]] internal slots.</p>
-          <p>When an AsyncDisposableStack callback function is called, the following steps are taken:</p>
+      <emu-clause id="sec-asyncdisposablestack.prototype.adopt">
+        <h1>AsyncDisposableStack.prototype.adopt( _value_, _onDisposeAsync_ )</h1>
+        <p>When the `adopt` function is called with two arguments, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _asyncDisposableStack_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
+          1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
+          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-asyncdisposablestack-adopt-callback-functions"></emu-xref>.
+          1. Set _F_.[[Argument]] to _value_.
+          1. Set _F_.[[OnDisposeAsyncCallback]] to _onDisposeAsync_.
+          1. Perform ? AddDisposableResource(_asyncDisposableStack_, *undefined*, ~async-dispose~, _F_).
+          1. Return _value_.
+        </emu-alg>
+
+        <emu-clause id="sec-asyncdisposablestack-adopt-callback-functions">
+          <h1>AsyncDisposableStack Adopt Callback Functions</h1>
+          <p>An <dfn>AsyncDisposableStack adopt callback function</dfn> is an anonymous built-in function that has [[Argument]] and [[OnDisposeAsyncCallback]] internal slots.</p>
+          <p>When an AsyncDisposableStack adopt callback function is called, the following steps are taken:</p>
           <emu-alg>
             1. Let _F_ be the active function object.
             1. Assert: IsCallable(_F_.[[OnDisposeAsyncCallback]]) is *true*.
             1. Return Call(_F_.[[OnDisposeAsyncCallback]], *undefined*, &laquo; _F_.[[Argument]] &raquo;).
           </emu-alg>
         </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncdisposablestack.prototype.defer">
+        <h1>AsyncDisposableStack.prototype.defer( _onDisposeAsync_ )</h1>
+        <p>When the `defer` function is called with one argument, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _asyncDisposableStack_ be the *this* value.
+          1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
+          1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
+          1. If IsCallable(_onDisposeAsync_) is *false*, throw a *TypeError* exception.
+          1. Perform ? AddDisposableResource(_asyncDisposableStack_, *undefined*, ~async-dispose~, _onDisposeAsync_).
+          1. Return *undefined*.
+        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-asyncdisposablestack.prototype.move">


### PR DESCRIPTION
Per the September 2022 plenary, the overloaded `use` method should be split into multiple, distinct methods. These methods are as follows:

- `use(value)` - Adds a disposable resource to the stack.
  - If the argument is `null` or `undefined`, it is returned as-is.
  - If the argument is not an Object, an error is thrown.
  - If the argument does not have a `[Symbol.dispose]()` method, an error is thrown.
- `adopt(value, onDispose)` - Adds a non-disposable resource to the stack with a dispose callback.
  - If `onDispose` is not callable, an error is thrown.
  - `value` can be any value, including `null` or `undefined`. It will always be tracked.
  - When the stack is disposed, the `onDispose` callback will be invoked with `value` as its argument (i.e., `onDispose(value)`).
- `defer(onDispose)` - Adds a callback to the stack.
  - If `onDispose` is not callable, an error is thrown.
  - When the stack is disposed, the `onDispose` callback will be invoked with no argument (i.e., `onDispose()`).

Fixes #102