### PR TITLE
Create a jagged `AggregateError` during `DisposeResources()`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1042,24 +1042,18 @@ contributors: Ron Buckton, Ecma International
       </h1>
       <dl class="header"></dl>
       <emu-alg>
-        1. If _errors_ is not present, let _errors_ be a new empty List.
         1. If _disposable_ is not *undefined*, then
           1. For each _resource_ of _disposable_.[[DisposableResourceStack]], in reverse list order, do
             1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
               1. If _result_.[[Type]] is ~throw~, then
-                1. Append _result_.[[Value]] to _errors_.
-        1. Let _errorsLength_ be the number of elements in _errors_.
-        1. If _errorsLength_ &gt; 0, then
-          1. Let _error_ be a newly created *AggregateError* object.
-          1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
-          1. If _completion_.[[Type]] is ~throw~, then
-            1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, "cause", _completion_.[[Value]]).
-          1. Return ThrowCompletion(_error_).
+                1. Let _disposeError_ be a newly created *AggregateError* object.
+                1. Let _errors_ be ! CreateArrayFromList( &laquo; _result_.[[Value]] &raquo; ).
+                1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _errors_ }).
+                1. If _completion_.[[Type]] is ~throw~, then
+                  1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, "cause", _completion_.[[Value]]).
+                1. Set _completion_ to ThrowCompletion(_disposeError_).
         1. Return _completion_.
       </emu-alg>
-      <emu-note>
-        Draft Note: This algorithm uses <a href="https://tc39.es/proposal-error-cause/#sec-createnonenumerabledatapropertyorthrow">CreateNonEnumerableDataPropertyOrThrow</a> from the Stage 3 <a href="https://github.com/tc39/proposal-error-cause">Error Cause proposal</a>.
-      </emu-note>
     </emu-clause>
   </emu-clause>
   </ins>

--- a/spec.emu
+++ b/spec.emu
@@ -1036,8 +1036,7 @@ contributors: Ron Buckton, Ecma International
       <h1>
         DisposeResources (
           _disposable_ : an object with a [[DisposableResourceStack]] internal slot or *undefined*,
-          _completion_ : a Completion Record,
-          optional _errors_ : a List,
+          _completion_ : a Completion Record
         ): a Completion Record
       </h1>
       <dl class="header"></dl>
@@ -1048,9 +1047,9 @@ contributors: Ron Buckton, Ecma International
               1. If _result_.[[Type]] is ~throw~, then
                 1. Let _disposeError_ be a newly created *AggregateError* object.
                 1. Let _errors_ be ! CreateArrayFromList( &laquo; _result_.[[Value]] &raquo; ).
-                1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _errors_ }).
+                1. Perform ! DefinePropertyOrThrow(_disposeError_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _errors_ }).
                 1. If _completion_.[[Type]] is ~throw~, then
-                  1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, "cause", _completion_.[[Value]]).
+                  1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_disposeError_, "cause", _completion_.[[Value]]).
                 1. Set _completion_ to ThrowCompletion(_disposeError_).
         1. Return _completion_.
       </emu-alg>


### PR DESCRIPTION
This change creates a jagged `AggregateError` in `DisposeResources()` such that the exceptions caught in the following two cases are identical:

```js
// case 1 - two+ using decls at same block level
try {
  using c = { [Symbol.dispose]() { throw new Error("c"); };
  using b = { [Symbol.dispose]() { throw new Error("b"); };
  throw new Error("a");
} catch (e) {
  e // AggregateError {
    //   errors: [Error { message: "c" }], 
    //   cause: AggregateError {
    //     errors: [Error { message: "b" }],
    //     cause: Error { message: "a" }
    //   }
    // }
}

// case 2 - two+ using decls at varying block levels
try {
  using c = { [Symbol.dispose]() { throw new Error("c"); };
  {
    using b = { [Symbol.dispose]() { throw new Error("b"); };
    throw new Error("a");
  }
} catch (e) {
  e // AggregateError {
    //   errors: [Error { message: "c" }], 
    //   cause: AggregateError {
    //     errors: [Error { message: "b" }],
    //     cause: Error { message: "a" }
    //   }
    // }
}
```

Per plenary, we will continue to use `AggregateError` rather than introducing a new error for this case.

Fixes #74