### PR TITLE
Remove Symbol.species support

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,6 @@ class DisposableStack {
   [Symbol.dispose]();
 
   [Symbol.toStringTag];
-  static get [Symbol.species]();
 }
 
 class AsyncDisposableStack {
@@ -766,7 +765,6 @@ class AsyncDisposableStack {
   [Symbol.asyncDispose]();
 
   [Symbol.toStringTag];
-  static get [Symbol.species]();
 }
 ```
 

--- a/spec.emu
+++ b/spec.emu
@@ -3518,18 +3518,6 @@ contributors: Ron Buckton, Ecma International
       <ul>
         <li>Has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
-
-      <!--
-      NOTE: If we decide not to support @@species, the following clause should be removed:
-      -->
-      <emu-clause id="sec-get-disposablestack-@@species">
-        <h1>get DisposableStack [ @@species ]</h1>
-        <p>`DisposableStack[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
-        <emu-alg>
-          1. Return the *this* value.
-        </emu-alg>
-        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-disposablestack-prototype-object">
@@ -3621,23 +3609,10 @@ contributors: Ron Buckton, Ecma International
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          <!--
-          NOTE: If we decide not to support @@species, the following steps should be removed:
-          -->
-          1. Let _C_ be ? SpeciesConstructor(_disposableStack_, %DisposableStack%).
-          1. Assert: IsConstructor(_C_) is *true*.
-          1. Let _newDisposableStack_ be ? Construct(_C_, &laquo; &raquo;).
-          1. Perform ? RequireInternalSlot(_newDisposableStack_, [[DisposableState]]).
-          1. If _newDisposableStack_.[[DisposableState]] is not ~pending~, throw a *TypeError* exception.
-          1. Append each element of _disposableStack_.[[DisposableResourceStack]] to _newDisposableStack_.[[DisposableResourceStack]].
-          <!--
-          NOTE: If we decide not to support @@species, we can use these steps instead:
-
           1. Let _newDisposableStack_ be ? OrdinaryCreateFromConstructor(%DisposableStack%, *"%DisposableStack.prototype%"*, &laquo; [[DisposableState]], [[DisposableResourceStack]], [[BoundDispose]] &raquo;).
           1. Set _newDisposableStack_.[[DisposableState]] to ~pending~.
           1. Set _newDisposableStack_.[[DisposableResourceStack]] to _disposableStack_.[[DisposableResourceStack]].
           1. Set _newDisposableStack_.[[BoundDispose]] to *undefined*.
-          -->
           1. Set _disposableStack_.[[DisposableResourceStack]] to a new empty List.
           1. Set _disposableStack_.[[DisposableState]] to ~disposed~.
           1. Return _newDisposableStack_.
@@ -3750,18 +3725,6 @@ contributors: Ron Buckton, Ecma International
       <ul>
         <li>Has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
       </ul>
-
-      <!--
-      NOTE: If we decide not to support @@species, the following clause should be removed:
-      -->
-      <emu-clause id="sec-get-asyncdisposablestack-@@species">
-        <h1>get AsyncDisposableStack [ @@species ]</h1>
-        <p>`AsyncDisposableStack[@@species]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
-        <emu-alg>
-          1. Return the *this* value.
-        </emu-alg>
-        <p>The value of the *"name"* property of this function is *"get [Symbol.species]"*.</p>
-      </emu-clause>
     </emu-clause>
 
     <emu-clause id="sec-properties-of-the-asyncdisposablestack-prototype-object">
@@ -3853,23 +3816,10 @@ contributors: Ron Buckton, Ecma International
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          <!--
-          NOTE: If we decide not to support @@species, the following steps should be removed:
-          -->
-          1. Let _C_ be ? SpeciesConstructor(_asyncDisposableStack_, %AsyncDisposableStack%).
-          1. Assert: IsConstructor(_C_) is *true*.
-          1. Let _newAsyncDisposableStack_ be ? Construct(_C_, &laquo; &raquo;).
-          1. Perform ? RequireInternalSlot(_newAsyncDisposableStack_, [[AsyncDisposableState]]).
-          1. If _newAsyncDisposableStack_.[[AsyncDisposableState]] is not ~pending~, throw a *TypeError* exception.
-          1. Append each element of _asyncDisposableStack_.[[DisposableResourceStack]] to _newAsyncDisposableStack_.[[DisposableResourceStack]].
-          <!--
-          NOTE: If we decide not to support @@species, we can use these steps instead:
-
           1. Let _newAsyncDisposableStack_ be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack, *"%AsyncDisposableStack.prototype%"*, &laquo; [[AsyncDisposableState]], [[DisposableResourceStack]], [[BoundDisposeAsync]] &raquo;).
           1. Set _newAsyncDisposableStack_.[[AsyncDisposableState]] to ~pending~.
           1. Set _newAsyncDisposableStack_.[[DisposableResourceStack]] to _asyncDisposableStack_.[[DisposableResourceStack]].
           1. Set _newAsyncDisposableStack_.[[BoundDisposeAsync]] to *undefined*.
-          -->
           1. Set _asyncDisposableStack_.[[DisposableResourceStack]] to a new empty List.
           1. Set _asyncDisposableStack_.[[AsyncDisposableState]] to ~disposed~.
           1. Return _newAsyncDisposableStack_.


### PR DESCRIPTION
This removes support for `Symbol.species`, per https://github.com/tc39/proposal-explicit-resource-management/issues/93#issuecomment-1249559013