### PR TITLE
Remove auto-bound 'dispose' and 'disposeAsync' getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,10 +747,9 @@ class DisposableStack {
   get disposed();
 
   /**
-   * Gets a bound function that when called invokes `Symbol.dispose` on this object.
-   * @returns {() => void} A function that when called disposes of any resources currently in this stack.
+   * Alias for `[Symbol.dispose]()`.
    */
-  get dispose();
+  dispose();
 
   /**
    * Adds a resource to the top of the stack. Has no effect if provided `null` or `undefined`.
@@ -801,10 +800,9 @@ class AsyncDisposableStack {
   get disposed();
 
   /**
-   * Gets a bound function that when called invokes `Symbol.disposeAsync` on this object.
-   * @returns {() => void} A function that when called disposes of any resources currently in this stack.
+   * Alias for `[Symbol.asyncDispose]()`.
    */
-  get disposeAsync();
+  disposeAsync();
 
   /**
    * Adds a resource to the top of the stack. Has no effect if provided `null` or `undefined`.

--- a/spec.emu
+++ b/spec.emu
@@ -3625,10 +3625,9 @@ contributors: Ron Buckton, Ecma International
         <p>When the `DisposableStack` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _disposableStack_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%DisposableStack.prototype%"*, &laquo; [[DisposableState]], [[DisposableResourceStack]], [[BoundDispose]] &raquo;).
+          1. Let _disposableStack_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%DisposableStack.prototype%"*, &laquo; [[DisposableState]], [[DisposableResourceStack]] &raquo;).
           1. Set _disposableStack_.[[DisposableState]] to ~pending~.
           1. Set _disposableStack_.[[DisposableResourceStack]] to a new empty List.
-          1. Set _disposableStack_.[[BoundDispose]] to *undefined*.
           1. Return _disposableStack_.
         </emu-alg>
       </emu-clause>
@@ -3663,35 +3662,16 @@ contributors: Ron Buckton, Ecma International
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-get-disposablestack.prototype.dispose">
-        <h1>get DisposableStack.prototype.dispose</h1>
-        <p>`DisposableStack.prototype.dispose` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+      <emu-clause id="sec-disposablestack.prototype.dispose">
+        <h1>DisposableStack.prototype.dispose ()</h1>
+        <p>When the `dispose` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
-          1. If _disposableStack_.[[BoundDispose]] is *undefined*, then
-            1. Let _dispose_ be GetMethod(_disposableStack_, @@dispose).
-            1. If _dispose_ is *undefined*, throw a *TypeError* exception.
-            1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-disposablestack-dispose-functions"></emu-xref>.
-            1. Set _F_.[[DisposableStack]] to _disposableStack_.
-            1. Set _F_.[[DisposeMethod]] to _dispose_.
-            1. Set _disposableStack_.[[BoundDispose]] to _F_.
-          1. Return _disposableStack_.[[BoundDispose]].
+          1. If _disposableStack_.[[DisposableState]] is ~disposed~, return *undefined*.
+          1. Set _disposableStack_.[[DisposableState]] to ~disposed~.
+          1. Return DisposeResources(_disposableStack_, NormalCompletion(*undefined*)).
         </emu-alg>
-
-        <emu-clause id="sec-disposablestack-dispose-functions">
-          <h1>DisposableStack Dispose Functions</h1>
-          <p>A <dfn>DisposableStack dispose function</dfn> is an anonymous built-in function object that has [[DisposableStack]] and [[DisposeMethod]] internal slots.</p>
-          <p>When a DisposableStack dispose function is called, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _disposableStack_ be _F_.[[DisposableStack]].
-            1. Let _dispose_ be _F_.[[DisposeMethod]].
-            1. Assert: Type(_disposableStack_) is Object and _disposableStack_ has a [[DisposableState]] internal slot.
-            1. Assert: IsCallable(_dispose_) is *true*.
-            1. Return Call(_dispose_, _disposableStack_, &laquo; &raquo;).
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype.use">
@@ -3759,10 +3739,9 @@ contributors: Ron Buckton, Ecma International
           1. Let _disposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. Let _newDisposableStack_ be ? OrdinaryCreateFromConstructor(%DisposableStack%, *"%DisposableStack.prototype%"*, &laquo; [[DisposableState]], [[DisposableResourceStack]], [[BoundDispose]] &raquo;).
+          1. Let _newDisposableStack_ be ? OrdinaryCreateFromConstructor(%DisposableStack%, *"%DisposableStack.prototype%"*, &laquo; [[DisposableState]], [[DisposableResourceStack]] &raquo;).
           1. Set _newDisposableStack_.[[DisposableState]] to ~pending~.
           1. Set _newDisposableStack_.[[DisposableResourceStack]] to _disposableStack_.[[DisposableResourceStack]].
-          1. Set _newDisposableStack_.[[BoundDispose]] to *undefined*.
           1. Set _disposableStack_.[[DisposableResourceStack]] to a new empty List.
           1. Set _disposableStack_.[[DisposableState]] to ~disposed~.
           1. Return _newDisposableStack_.
@@ -3771,15 +3750,7 @@ contributors: Ron Buckton, Ecma International
 
       <emu-clause id="sec-disposablestack.prototype-@@dispose">
         <h1>DisposableStack.prototype [ @@dispose ] ()</h1>
-        <p>When the `@@dispose` method is called, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _disposableStack_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
-          1. If _disposableStack_.[[DisposableState]] is ~disposed~, return *undefined*.
-          1. Set _disposableStack_.[[DisposableState]] to ~disposed~.
-          1. Return DisposeResources(_disposableStack_, NormalCompletion(*undefined*)).
-        </emu-alg>
-        <p>The value of the *"name"* property of this function is *"[Symbol.dispose]"*.</p>
+        <p>The initial value of the @@dispose property is %DisposableStack.prototype.dispose%, defined in <emu-xref href="#sec-disposablestack.prototype.dispose"></emu-xref>.</p>
       </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype-@@toStringTag">
@@ -3819,14 +3790,6 @@ contributors: Ron Buckton, Ecma International
               A List of DisposableResource Records.
             </td>
           </tr>
-          <tr>
-            <td>
-              [[BoundDispose]]
-            </td>
-            <td>
-              Either *undefined* or a function object that caches the function returned by the `DisposableStack.prototype.dispose` accessor (<emu-xref href="#sec-get-disposablestack.prototype.dispose"></emu-xref>).
-            </td>
-          </tr>
           </tbody>
         </table>
       </emu-table>
@@ -3860,10 +3823,9 @@ contributors: Ron Buckton, Ecma International
         <p>When the `AsyncDisposableStack` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is *undefined*, throw a *TypeError* exception.
-          1. Let _asyncDisposableStack_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncDisposableStack.prototype%"*, &laquo; [[AsyncDisposableState]], [[DisposableResourceStack]], [[BoundDisposeAsync]] &raquo;).
+          1. Let _asyncDisposableStack_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%AsyncDisposableStack.prototype%"*, &laquo; [[AsyncDisposableState]], [[DisposableResourceStack]] &raquo;).
           1. Set _asyncDisposableStack_.[[AsyncDisposableState]] to ~pending~.
           1. Set _asyncDisposableStack_.[[DisposableResourceStack]] to a new empty List.
-          1. Set _asyncDisposableStack_.[[BoundDisposeAsync]] to *undefined*.
           1. Return _asyncDisposableStack_.
         </emu-alg>
       </emu-clause>
@@ -3898,35 +3860,24 @@ contributors: Ron Buckton, Ecma International
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-get-asyncdisposablestack.prototype.disposeAsync">
-        <h1>get AsyncDisposableStack.prototype.disposeAsync</h1>
-        <p>`AsyncDisposableStack.prototype.disposeAsync` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
+      <emu-clause id="sec-asyncdisposablestack.prototype.disposeAsync">
+        <h1>AsyncDisposableStack.prototype.disposeAsync()</h1>
+        <p>When the `disposeAsync` method is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _asyncDisposableStack_ be the *this* value.
-          1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
-          1. If _asyncDisposableStack_.[[BoundDisposeAsync]] is *undefined*, then
-            1. Let _disposeAsync_ be GetMethod(_asyncDisposableStack_, @@asyncDispose).
-            1. If _disposeAsync_ is *undefined*, throw a *TypeError* exception.
-            1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-asyncdisposablestack-dispose-functions"></emu-xref>.
-            1. Set _F_.[[AsyncDisposableStack]] to _asyncDisposableStack_.
-            1. Set _F_.[[DisposeAsyncMethod]] to _disposeAsync_.
-            1. Set _asyncDisposableStack_.[[BoundDisposeAsync]] to _F_.
-          1. Return _asyncDisposableStack_.[[BoundDisposeAsync]].
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. If _asyncDisposableStack_ does not have an [[AsyncDisposableState]] internal slot, then
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, then
+            1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. Set _asyncDisposableStack_.[[AsyncDisposableState]] to ~disposed~.
+          1. Let _result_ be DisposeResources(_asyncDisposableStack_, NormalCompletion(*undefined*)).
+          1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+          1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
+          1. Return _promiseCapability_.[[Promise]].
         </emu-alg>
-
-        <emu-clause id="sec-asyncdisposablestack-dispose-functions">
-          <h1>AsyncDisposableStack Dispose Functions</h1>
-          <p>An AsyncDisposableStack dispose function is an anonymous built-in function that has [[AsyncDisposableStack]] and [[DisposeAsyncMethod]] internal slots.</p>
-          <p>When an AsyncDisposableStack dispose function is called, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Let _asyncDisposableStack_ be _F_.[[AsyncDisposableStack]].
-            1. Let _disposeAsync_ be _F_.[[DisposeAsyncMethod]].
-            1. Assert: Type(_asyncDisposableStack_) is Object and _asyncDisposableStack_ has an [[AsyncDisposableState]] internal slot.
-            1. Assert: IsCallable(_disposeAsync_) is *true*.
-            1. Return Call(_disposeAsync_, _asyncDisposableStack_, &laquo; &raquo;).
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-asyncdisposablestack.prototype.use">
@@ -3994,10 +3945,9 @@ contributors: Ron Buckton, Ecma International
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Perform ? RequireInternalSlot(_asyncDisposableStack_, [[AsyncDisposableState]]).
           1. If _asyncDisposableStack_.[[AsyncDisposableState]] is ~disposed~, throw a *ReferenceError* exception.
-          1. Let _newAsyncDisposableStack_ be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack, *"%AsyncDisposableStack.prototype%"*, &laquo; [[AsyncDisposableState]], [[DisposableResourceStack]], [[BoundDisposeAsync]] &raquo;).
+          1. Let _newAsyncDisposableStack_ be ? OrdinaryCreateFromConstructor(%AsyncDisposableStack%, *"%AsyncDisposableStack.prototype%"*, &laquo; [[AsyncDisposableState]], [[DisposableResourceStack]] &raquo;).
           1. Set _newAsyncDisposableStack_.[[AsyncDisposableState]] to ~pending~.
           1. Set _newAsyncDisposableStack_.[[DisposableResourceStack]] to _asyncDisposableStack_.[[DisposableResourceStack]].
-          1. Set _newAsyncDisposableStack_.[[BoundDisposeAsync]] to *undefined*.
           1. Set _asyncDisposableStack_.[[DisposableResourceStack]] to a new empty List.
           1. Set _asyncDisposableStack_.[[AsyncDisposableState]] to ~disposed~.
           1. Return _newAsyncDisposableStack_.
@@ -4006,7 +3956,7 @@ contributors: Ron Buckton, Ecma International
 
       <emu-clause id="sec-asyncdisposablestack.prototype-@@asyncDispose">
         <h1>AsyncDisposableStack.prototype [ @@asyncDispose ] ()</h1>
-        <p>When the `@@asyncDispose` method is called, the following steps are taken:</p>
+        <p>The initial value of the @@asyncDispose property is %AsyncDisposableStack.prototype.disposeAsync%, defined in <emu-xref href="#sec-asyncdisposablestack.prototype.disposeAsync"></emu-xref>.</p>
         <emu-alg>
           1. Let _asyncDisposableStack_ be the *this* value.
           1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
@@ -4060,14 +4010,6 @@ contributors: Ron Buckton, Ecma International
             </td>
             <td>
               A List of DisposableResource records.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              [[BoundDisposeAsync]]
-            </td>
-            <td>
-              Either *undefined* or a function object that caches the function returned by the `AsyncDisposableStack.prototype.disposeAsync` accessor (<emu-xref href="#sec-get-asyncdisposablestack.prototype.disposeAsync"></emu-xref>).
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
Changes the auto-bound `dispose` and `disposeAsync` methods/getters into standard methods.