### PR TITLE
Adds `SuppressedError`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -712,6 +712,17 @@ contributors: Ron Buckton, Ecma International
             </tr>
             <tr>
               <td>
+                <ins>%SuppressedError%</ins>
+              </td>
+              <td>
+                <ins>`SuppressedError`</ins>
+              </td>
+              <td>
+                <ins>The `SuppressedError` constructor (<emu-xref href="#sec-suppressederror-constructor"></emu-xref>)</ins>
+              </td>
+            </tr>
+            <tr>
+              <td>
                 %Symbol%
               </td>
               <td>
@@ -1037,29 +1048,25 @@ contributors: Ron Buckton, Ecma International
         DisposeResources (
           _disposable_ : an object with a [[DisposableResourceStack]] internal slot or *undefined*,
           _completion_ : a Completion Record,
-          optional _errors_ : a List,
         ): a Completion Record
       </h1>
       <dl class="header"></dl>
       <emu-alg>
-        1. If _errors_ is not present, let _errors_ be a new empty List.
         1. If _disposable_ is not *undefined*, then
           1. For each _resource_ of _disposable_.[[DisposableResourceStack]], in reverse list order, do
             1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
               1. If _result_.[[Type]] is ~throw~, then
-                1. Append _result_.[[Value]] to _errors_.
-        1. Let _errorsLength_ be the number of elements in _errors_.
-        1. If _errorsLength_ &gt; 0, then
-          1. Let _error_ be a newly created *AggregateError* object.
-          1. Perform ! DefinePropertyOrThrow(_error_, *"errors"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: ! CreateArrayFromList(_errors_) }).
-          1. If _completion_.[[Type]] is ~throw~, then
-            1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, "cause", _completion_.[[Value]]).
-          1. Return ThrowCompletion(_error_).
+                1. If _completion_.[[Type]] is ~throw~, then
+                  1. Set _result_ to _result_.[[Value]].
+                  1. Let _suppressed_ be _completion_.[[Value]].
+                  1. Let _error_ be a newly created *SuppressedError* object.
+                  1. Perform ! DefinePropertyOrThrow(_error_, *"error"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _result_ }).
+                  1. Perform ! DefinePropertyOrThrow(_error_, *"suppressed"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _suppressed_ }).
+                  1. Set _completion_ to ThrowCompletion(_error_).
+                1. Else,
+                  1. Set _completion_ to _result_.
         1. Return _completion_.
       </emu-alg>
-      <emu-note>
-        Draft Note: This algorithm uses <a href="https://tc39.es/proposal-error-cause/#sec-createnonenumerabledatapropertyorthrow">CreateNonEnumerableDataPropertyOrThrow</a> from the Stage 3 <a href="https://github.com/tc39/proposal-error-cause">Error Cause proposal</a>.
-      </emu-note>
     </emu-clause>
   </emu-clause>
   </ins>
@@ -3344,6 +3351,121 @@ contributors: Ron Buckton, Ecma International
         </emu-note>
       </emu-clause>
     </emu-clause>
+  </emu-clause>
+</emu-clause>
+
+<emu-clause id="sec-fundamental-objects">
+  <h1>Fundamental Objects</h1>
+
+  <emu-clause id="sec-error-objects">
+    <h1>Error Objects</h1>
+    <p>Instances of Error objects are thrown as exceptions when runtime errors occur. The Error objects may also serve as base objects for user-defined exception classes.</p>
+    <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref> or a new instance of <ins>either the</ins> AggregateError object defined in <emu-xref href="#sec-aggregate-error-objects"></emu-xref><ins>, or the SuppressedError object defined in <emu-xref href="#sec-suppressederror-objects"></emu-xref></ins>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the *"name"* property of the prototype object, in the implementation-defined *"message"* property of the prototype object, and in the presence of the %AggregateError%-specific *"errors"* property<ins> or the %SuppressedError%-specific *"error"* and *"suppressed"* properties</ins>.</p>
+
+    <emu-clause id="sec-properties-of-error-instances">
+      <h1>Properties of Error Instances</h1>
+      <p>Error instances are ordinary objects that inherit properties from the Error prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified uses of [[ErrorData]] is to identify Error, AggregateError, <ins>SuppressedError,</ins> and _NativeError_ instances as Error objects within `Object.prototype.toString`.</p>
+    </emu-clause>
+
+    <emu-clause id="sec-nativeerror-object-structure">
+      <h1>_NativeError_ Object Structure</h1>
+      <p>When an ECMAScript implementation detects a runtime error, it throws a new instance of one of the _NativeError_ objects defined in <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>. Each of these objects has the structure described below, differing only in the name used as the constructor name instead of _NativeError_, in the *"name"* property of the prototype object, and in the implementation-defined *"message"* property of the prototype object.</p>
+      <p>For each error object, references to _NativeError_ in the definition should be replaced with the appropriate error object name from <emu-xref href="#sec-native-error-types-used-in-this-standard"></emu-xref>.</p>
+
+      <emu-clause id="sec-properties-of-nativeerror-instances">
+        <h1>Properties of _NativeError_ Instances</h1>
+        <p>_NativeError_ instances are ordinary objects that inherit properties from their _NativeError_ prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified use of [[ErrorData]] is by `Object.prototype.toString` (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>) to identify Error, AggregateError, <ins>SuppressedError,</ins> or _NativeError_ instances.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-aggregate-error-objects">
+      <h1>AggregateError Objects</h1>
+
+      <emu-clause id="sec-properties-of-aggregate-error-instances">
+        <h1>Properties of AggregateError Instances</h1>
+        <p>AggregateError instances are ordinary objects that inherit properties from their AggregateError prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified use of [[ErrorData]] is by `Object.prototype.toString` (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>) to identify Error, AggregateError, <ins>SuppressedError,</ins> or _NativeError_ instances.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <ins class="block">
+    <emu-clause id="sec-suppressederror-objects">
+      <h1>SuppressedError Objects</h1>
+
+      <emu-clause id="sec-suppressederror-constructor">
+        <h1>The SuppressedError Constructor</h1>
+        <p>The SuppressedError constructor:</p>
+        <ul>
+          <li>is <dfn>%SuppressedError%</dfn>.</li>
+          <li>is the initial value of the *"SuppressedError"* property of the global object.</li>
+          <li>creates and initializes a new SuppressedError object when called as a function rather than as a constructor. Thus the function call `SuppressedError(…)` is equivalent to the object creation expression `new SuppressedError(…)` with the same arguments.</li>
+          <li>may be used as the value of an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified SuppressedError behaviour must include a `super` call to the SuppressedError constructor to create and initialize subclass instances with an [[ErrorData]] internal slot.</li>
+        </ul>
+
+        <emu-clause id="sec-suppressederror">
+          <h1>SuppressedError ( _error_, _suppressed_, _message_ [ , _options_ ] )</h1>
+          <p>This function performs the following steps when called:</p>
+          <emu-alg>
+            1. If NewTarget is *undefined*, let _newTarget_ be the active function object; else let _newTarget_ be NewTarget.
+            1. Let _O_ be ? OrdinaryCreateFromConstructor(_newTarget_, *"%SuppressedError.prototype%"*, « [[ErrorData]] »).
+            1. If _message_ is not *undefined*, then
+              1. Let _msg_ be ? ToString(_message_).
+              1. Perform CreateNonEnumerableDataPropertyOrThrow(_O_, *"message"*, _msg_).
+            1. Perform ? InstallErrorCause(_O_, _options_).
+            1. Perform ! DefinePropertyOrThrow(_O_, *"error"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _error_ }).
+            1. Perform ! DefinePropertyOrThrow(_O_, *"suppressed"*, PropertyDescriptor { [[Configurable]]: *true*, [[Enumerable]]: *false*, [[Writable]]: *true*, [[Value]]: _suppressed_ }).
+            1. Return _O_.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-properties-of-the-suppressederror-constructors">
+        <h1>Properties of the SuppressedError Constructor</h1>
+        <p>The SuppressedError constructor:</p>
+        <ul>
+          <li>has a [[Prototype]] internal slot whose value is %Error%.</li>
+          <li>has the following properties:</li>
+        </ul>
+
+        <emu-clause id="sec-suppressederror.prototype">
+          <h1>SuppressedError.prototype</h1>
+          <p>The initial value of `SuppressedError.prototype` is %SuppressedError.prototype%.</p>
+          <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-properties-of-the-suppressederror-prototype-objects">
+        <h1>Properties of the SuppressedError Prototype Object</h1>
+        <p>The <dfn>SuppressedError prototype object</dfn>:</p>
+        <ul>
+          <li>is <dfn>%SuppressedError.prototype%</dfn>.</li>
+          <li>is an ordinary object.</li>
+          <li>is not an Error instance or an SuppressedError instance and does not have an [[ErrorData]] internal slot.</li>
+          <li>has a [[Prototype]] internal slot whose value is %Error.prototype%.</li>
+        </ul>
+
+        <emu-clause id="sec-suppressederror.prototype.constructor">
+          <h1>SuppressedError.prototype.constructor</h1>
+          <p>The initial value of `SuppressedError.prototype.constructor` is %SuppressedError%.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-suppressederror.prototype.message">
+          <h1>SuppressedError.prototype.message</h1>
+          <p>The initial value of `SuppressedError.prototype.message` is the empty String.</p>
+        </emu-clause>
+
+        <emu-clause id="sec-suppressederror.prototype.name">
+          <h1>SuppressedError.prototype.name</h1>
+          <p>The initial value of `SuppressedError.prototype.name` is *"SuppressedError"*.</p>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-properties-of-suppressederror-instances">
+        <h1>Properties of SuppressedError Instances</h1>
+        <p>SuppressedError instances are ordinary objects that inherit properties from their SuppressedError prototype object and have an [[ErrorData]] internal slot whose value is *undefined*. The only specified use of [[ErrorData]] is by `Object.prototype.toString` (<emu-xref href="#sec-object.prototype.tostring"></emu-xref>) to identify Error, AggregateError, SuppressedError, or _NativeError_ instances.</p>
+      </emu-clause>
+    </emu-clause>
+    </ins>
+
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
Adds a new `SuppressedError` built-in `Error` subclass to represent an error that suppresses another error as a result of disposal.

A `SuppressedError` is defined as:

```js
class SuppressedError extends Error {
  constructor(error, suppressed, message, options);
  name; // "SuppressedError"
  error; // The error that resulted in a suppression.
  suppressed; // The error that was suppressed.
  message;
}
```

Such that, given the following:

```js
try {
  using a = { [Symbol.dispose]() { throw new Error("a"); } };
  using b = { [Symbol.dispose]() { throw new Error("b"); } };
  throw new Error("c");
}
catch (e) {
  e;
}
```

The exception caught by `e` would have the following shape:

```js
SuppressedError {
  error: Error("a"), // from resource 'a'
  suppressed: SuppressedError {
    error: Error("b"), // from resource 'b'
    suppressed: Error("c"), // from the body
  }
}
```

This is due to the following execution flow:
1. Resource `a` is tracked for disposal
2. Resource `b` is tracked for disposal
3. `Error("c")` is thrown, triggering disposal
4. Resource `b` is disposed, throwing `Error("b")` and suppressing `Error("c")`, producing a `SuppressedError(Error("b"), Error("c"))`.
5. Resource `a` is disposed, throwing `Error("a")` and suppressing `SuppressedError(Error("b"), Error("c"))`.

Supersedes #104
Fixes #74
Fixes #112