### PR TITLE
Move BindingPattern restriction for 'using' to an early error

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -2456,7 +2456,7 @@ contributors: Ron Buckton, Ecma International
         ForInOfStatement[Yield, Await, Return] :
           `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` ForDeclaration[?Yield, ?Await, <ins>~Using</ins>] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` [lookahead &notin; {`let`, `async` `of`}] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` <ins>[lookahead != `using` `of`]</ins> ForDeclaration[?Yield, ?Await, <ins>+Using</ins>] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
@@ -2480,7 +2480,7 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>ForBinding : BindingPattern</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if this |ForBinding| is contained in a |ForDeclaration| and IsUsingDeclaration of that |ForDeclaration| is *true*.
+            It is a Syntax Error if this |ForBinding| is contained within a |ForDeclaration| and IsUsingDeclaration of that |ForDeclaration| is *true*.
           </li>
         </ul>
         </ins>

--- a/spec.emu
+++ b/spec.emu
@@ -2101,7 +2101,7 @@ contributors: Ron Buckton, Ecma International
       <h2>Syntax</h2>
       <emu-grammar type="definition">
         LexicalDeclaration[In, Yield, Await] :
-          LetOrConst BindingList[?In, ?Yield, ?Await, <ins>~Using</ins>] `;`
+          LetOrConst BindingList[?In, ?Yield, ?Await] `;`
           <ins>UsingDeclaration[?In, ?Yield, ?Await]</ins>
 
         LetOrConst :
@@ -2110,17 +2110,16 @@ contributors: Ron Buckton, Ecma International
 
         <ins>
         UsingDeclaration[In, Yield, Await] :
-          `using` [no LineTerminator here] [lookahead != `await`] BindingList[?In, ?Yield, ?Await, +Using] `;`
+          `using` [no LineTerminator here] [lookahead != `await`] BindingList[?In, ?Yield, ?Await] `;`
         </ins>
 
-        BindingList[In, Yield, Await, <ins>Using</ins>] :
-          LexicalBinding[?In, ?Yield, ?Await, <ins>?Using</ins>]
-          BindingList[?In, ?Yield, ?Await, <ins>?Using</ins>] `,` LexicalBinding[?In, ?Yield, ?Await, <ins>?Using</ins>]
+        BindingList[In, Yield, Await] :
+          LexicalBinding[?In, ?Yield, ?Await]
+          BindingList[?In, ?Yield, ?Await] `,` LexicalBinding[?In, ?Yield, ?Await]
 
-        LexicalBinding[In, Yield, Await, <ins>Using</ins>] :
+        LexicalBinding[In, Yield, Await] :
           BindingIdentifier[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]?
-          <del>BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]</del>
-          <ins>[~Using] BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]</ins>
+          BindingPattern[?Yield, ?Await] Initializer[?In, ?Yield, ?Await]
       </emu-grammar>
 
       <emu-clause id="sec-let-and-const-declarations-static-semantics-early-errors">
@@ -2155,6 +2154,14 @@ contributors: Ron Buckton, Ecma International
             </li>
           </ul>
         </emu-note>
+        <emu-grammar>
+          LexicalBinding : BindingPattern Initializer
+        </emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if IsUsingDeclaration of the |LexicalDeclaration| containing this |LexicalBinding| is *true*.
+          </li>
+        </ul>
         </ins>
       </emu-clause>
 
@@ -2448,24 +2455,36 @@ contributors: Ron Buckton, Ecma International
       <emu-grammar type="definition">
         ForInOfStatement[Yield, Await, Return] :
           `for` `(` [lookahead != `let` `[`] LeftHandSideExpression[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` `var` ForBinding[?Yield, ?Await, <ins>~Using</ins>] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` ForDeclaration[?Yield, ?Await, <ins>~Using</ins>] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` `var` ForBinding[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` ForDeclaration[?Yield, ?Await] `in` Expression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` [lookahead &notin; {`let`, `async` `of`}] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          `for` `(` `var` ForBinding[?Yield, ?Await, <ins>~Using</ins>] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          `for` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           `for` `(` <ins>[lookahead != `using` `of`]</ins> ForDeclaration[?Yield, ?Await, <ins>+Using</ins>] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           [+Await] `for` `await` `(` [lookahead != `let`] LeftHandSideExpression[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
-          [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await, <ins>~Using</ins>] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
+          [+Await] `for` `await` `(` `var` ForBinding[?Yield, ?Await] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
           [+Await] `for` `await` `(` <ins>[lookahead != `using` `of`]</ins> ForDeclaration[?Yield, ?Await, <ins>+Using</ins>] `of` AssignmentExpression[+In, ?Yield, ?Await] `)` Statement[?Yield, ?Await, ?Return]
 
         ForDeclaration[Yield, Await, <ins>Using</ins>] :
-          LetOrConst ForBinding[?Yield, ?Await, <ins>~Using</ins>]
-          <ins>[+Using] `using` [no LineTerminator here] [lookahead != `await`] ForBinding[?Yield, ?Await, +Using]</ins>
+          LetOrConst ForBinding[?Yield, ?Await]
+          <ins>[+Using] `using` [no LineTerminator here] [lookahead != `await`] ForBinding[?Yield, ?Await]</ins>
 
-        ForBinding[Yield, Await, <ins>Using</ins>] :
+        ForBinding[Yield, Await] :
           BindingIdentifier[?Yield, ?Await]
-          <del>BindingPattern[?Yield, ?Await]</del>
-          <ins>[~Using] BindingPattern[?Yield, ?Await]</ins>
+          BindingPattern[?Yield, ?Await]
       </emu-grammar>
+
+      <emu-clause id="sec-for-in-and-for-of-statements-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+
+        <ins class="block">
+        <emu-grammar>ForBinding : BindingPattern</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if this |ForBinding| is contained in a |ForDeclaration| and IsUsingDeclaration of that |ForDeclaration| is *true*.
+          </li>
+        </ul>
+        </ins>
+      </emu-clause>
 
       <emu-clause id="sec-runtime-semantics-fordeclarationbindinginstantiation" oldids="sec-runtime-semantics-bindinginstantiation" type="sdo">
         <h1>


### PR DESCRIPTION
Per editor feedback in https://github.com/tc39/proposal-async-explicit-resource-management/issues/9, this moves the _BindingPattern_ restriction for `using` declarations to an Early Error to avoid ambiguity from using the `Using` parameter in two different ways. The early error condition is roughly equivalent to how `const` declarations report an early error on a missing _Initializer_.