### PR TITLE
Revert 'await' restriction

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -2107,7 +2107,7 @@ contributors: Ron Buckton, Ecma International
 
         <ins>
         UsingDeclaration[In, Yield, Await] :
-          `using` [no LineTerminator here] [lookahead != `await`] BindingList[?In, ?Yield, ?Await, ~Pattern] `;`
+          `using` [no LineTerminator here] BindingList[?In, ?Yield, ?Await, ~Pattern] `;`
         </ins>
 
         BindingList[In, Yield, Await, <ins>Pattern</ins>] :
@@ -2130,9 +2130,6 @@ contributors: Ron Buckton, Ecma International
         <ul>
           <li>
             It is a Syntax Error if the BoundNames of |BindingList| contains *"let"*.
-          </li>
-          <li>
-            It is a Syntax Error if the BoundNames of |BindingList| contains *"await"*.
           </li>
           <li>
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
@@ -2390,7 +2387,7 @@ contributors: Ron Buckton, Ecma International
 
         ForDeclaration[Yield, Await, <ins>Using</ins>] :
           LetOrConst ForBinding[?Yield, ?Await, <ins>+Pattern</ins>]
-          <ins>[+Using] `using` [no LineTerminator here] [lookahead != `await`] ForBinding[?Yield, ?Await, ~Pattern]</ins>
+          <ins>[+Using] `using` [no LineTerminator here] ForBinding[?Yield, ?Await, ~Pattern]</ins>
 
         ForBinding[Yield, Await, <ins>Pattern</ins>] :
           BindingIdentifier[?Yield, ?Await]


### PR DESCRIPTION
Per March 2023 plenary consensus, this reverts the `await` identifier restriction in `using`.