### PR TITLE
Update DisposableStack.p.adopt to use an Abstract Closure

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -4453,23 +4453,12 @@ contributors: Ron Buckton, Ecma International
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, throw a *ReferenceError* exception.
           1. If IsCallable(_onDispose_) is *false*, throw a *TypeError* exception.
-          1. Let _F_ be a new built-in function object as defined in <emu-xref href="#sec-disposablestack-adopt-callback-functions"></emu-xref>.
-          1. Set _F_.[[Argument]] to _value_.
-          1. Set _F_.[[OnDisposeCallback]] to _onDispose_.
+          1. Let _closure_ be a new Abstract Closure with no parameters that captures _value_ and _onDispose_ and performs the following steps when called:
+            1. Return ? Call(_onDispose_, *undefined*, &laquo; _value_ &raquo;).
+          1. Let _F_ be CreateBuiltinFunction(_closure_, 0, *""*, « »).
           1. Perform ? AddDisposableResource(_disposableStack_.[[DisposeCapability]], *undefined*, ~sync-dispose~, _F_).
           1. Return _value_.
         </emu-alg>
-
-        <emu-clause id="sec-disposablestack-adopt-callback-functions">
-          <h1>DisposableStack Adopt Callback Functions</h1>
-          <p>A <dfn>DisposableStack adopt callback function</dfn> is an anonymous built-in function object that has [[Argument]] and [[OnDisposeCallback]] internal slots.</p>
-          <p>When a DisposableStack adopt callback function is called, the following steps are taken:</p>
-          <emu-alg>
-            1. Let _F_ be the active function object.
-            1. Assert: IsCallable(_F_.[[OnDisposeCallback]]) is *true*.
-            1. Return Call(_F_.[[OnDisposeCallback]], *undefined*, &laquo; _F_.[[Argument]] &raquo;).
-          </emu-alg>
-        </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype.defer">


### PR DESCRIPTION
This updates the algorithm text for `DisposableStack.prototype.adopt` to align with `AsyncDisposableStack.prototype.adopt` and the much of the rest of ECMA-262 which now uses an Abstract Closure passed to `CreateBuiltinFunction` instead of a separate set of steps.

NOTE: This is intended to be purely an editorial change with no normative impact.