### PR TITLE
Suggest also using a FinalizationRegistry when a Disposable holds a native handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1823,14 +1823,13 @@ function nativeCloseFile(handle) { ... }
 class SafeFileHandle {
   static #finalizer = new FinalizationRegistry(nativeCloseFile);
 
-  #unregisterToken = {};
   #handle;
 
   constructor(file) {
     this.#handle = nativeOpenFile(file);
 
     // Register for finalization
-    SafeHandle.#finalizer.register(this, handle, this.#unregisterToken);
+    SafeHandle.#finalizer.register(this, handle, /*unregisterToken*/ this);
   }
 
   get disposed() {
@@ -1845,7 +1844,7 @@ class SafeFileHandle {
   dispose() {
     if (this.#handle !== 0) {
       // This instance no longer needs finalization
-      SafeHandle.#finalizer.unregister(this.#unregisterToken);
+      SafeHandle.#finalizer.unregister(this);
 
       // Perform cleanup
       const handle = this.#handle;

--- a/README.md
+++ b/README.md
@@ -1829,7 +1829,7 @@ class SafeFileHandle {
     this.#handle = nativeOpenFile(file);
 
     // Register for finalization
-    SafeHandle.#finalizer.register(this, handle, /*unregisterToken*/ this);
+    SafeFileHandle.#finalizer.register(this, this.#handle, /*unregisterToken*/ this);
   }
 
   get disposed() {
@@ -1844,7 +1844,7 @@ class SafeFileHandle {
   dispose() {
     if (this.#handle !== 0) {
       // This instance no longer needs finalization
-      SafeHandle.#finalizer.unregister(this);
+      SafeFileHandle.#finalizer.unregister(this);
 
       // Perform cleanup
       const handle = this.#handle;

--- a/spec.emu
+++ b/spec.emu
@@ -4313,6 +4313,7 @@ contributors: Ron Buckton, Ecma International
                 <p>Invoking this method notifies the <em>Disposable</em> object that the caller does not intend to continue to use this object. This method should perform any necessary logic to perform explicit clean-up of the resource including, but not limited to, file system handles, streams, host objects, etc. When an exception is thrown from this method, it typically means that the resource could not be explicitly freed.</p>
                 <p>If called more than once on the same object, the function should not throw an exception. However, this requirement is not enforced.</p>
                 <p>When using a <em>Disposable</em> object, it is good practice to create the instance with a `using` declaration, as the resource will be automatically disposed when the |Block| or |Module| immediately containing the declaration has been evaluated.</p>
+                <p>When implementing a <em>Disposable</em> object that holds a native handle (i.e., a pointer, a file descriptor, etc.), it is good practice to also use a `FinalizationRegistry` to ensure the handle is closed if the <em>Disposable</em> object is garbage collected without having been disposed, as well as use the `FinalizationRegistry`'s `unregister` method to prevent finalization if the object is disposed before it is garbage collected.</p>
               </td>
             </tr>
             </tbody>


### PR DESCRIPTION
This adds a non-normative note to suggest that it is good practice to also use a `FinalizationRegistry` when using `@@dispose` to implement a disposable object that holds a native handle, so as to ensure the handle is properly closed if the disposable object is garbage collected without having been disposed.

Including this suggestion is based on this discussion: https://github.com/tc39/proposal-explicit-resource-management/issues/159#issuecomment-1588158664

cc: @tc39/ecma262-editors 