### PR TITLE
Correctly use _hint_ in ForIn/OfBodyEvaluation

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -2985,10 +2985,7 @@ contributors: Ron Buckton, Ecma International
                 1. Let _lhsName_ be the sole element of BoundNames of _lhs_.
                 1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
                 1. <del>Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_)).</del>
-                1. <ins>If IsUsingDeclaration of _lhs_ is *true*, then</ins>
-                  1. <ins>Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_, ~sync-dispose~)).</ins>
-                1. <ins>Else,</ins>
-                  1. <ins>Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_, ~normal~)).</ins>
+                1. <ins>Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_, _hint_)).</ins>
             1. If _status_ is an abrupt completion, then
               1. <ins>If _iterationEnv_ is not *undefined*, then</ins>
                 1. <ins>Set _status_ to Completion(DisposeResources(_iterationEnv_.[[DisposeCapability]], _status_)).</ins>


### PR DESCRIPTION
This fixes an oversight in ForIn/OfBodyEvaluation to correctly use the _hint_ variable initialized at the top of the algorithm when initializing the _lhsRef_ binding via `InitializeReferenceBinding`. This is necessary to correctly initialize a resource that uses `Symbol.asyncDispose` in the following statement:

```js
for (await using x of y) {
}
```

cc: @tc39/ecma262-editors