### PR TITLE
Fix `DisposeCapability` leak

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -927,7 +927,7 @@ contributors: Ron Buckton, Ecma International
               [[DisposableResourceStack]]
             </td>
             <td>
-              a List of DisposableResource Records
+              A List of DisposableResource Records.
             </td>
             <td>
               The resources to be disposed. Resources are added in the order they are initialized, and are disposed in reverse order.

--- a/spec.emu
+++ b/spec.emu
@@ -927,7 +927,7 @@ contributors: Ron Buckton, Ecma International
               [[DisposableResourceStack]]
             </td>
             <td>
-              either *undefined* or a List of DisposableResource Records
+              a List of DisposableResource Records
             </td>
             <td>
               The resources to be disposed. Resources are added in the order they are initialized, and are disposed in reverse order.
@@ -1018,7 +1018,6 @@ contributors: Ron Buckton, Ecma International
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not *undefined*.
         1. If _method_ is not present then,
           1. If _V_ is either *null* or *undefined* and _hint_ is ~sync-dispose~, then
             1. Return ~unused~.
@@ -1108,7 +1107,6 @@ contributors: Ron Buckton, Ecma International
       </h1>
       <dl class="header"></dl>
       <emu-alg>
-        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not *undefined*.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
           1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
           1. If _result_.[[Type]] is ~throw~, then
@@ -1122,7 +1120,7 @@ contributors: Ron Buckton, Ecma International
             1. Else,
               1. Set _completion_ to _result_.
         1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
-        1. Set _disposeCapability_.[[DisposableResourceStack]] to *undefined*.
+        1. Set _disposeCapability_.[[DisposableResourceStack]] to a new empty List.
         1. Return _completion_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -1119,7 +1119,7 @@ contributors: Ron Buckton, Ecma International
               1. Set _completion_ to ThrowCompletion(_error_).
             1. Else,
               1. Set _completion_ to _result_.
-        1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
+        1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded in implementations, such as by garbage collection, at this point.
         1. Set _disposeCapability_.[[DisposableResourceStack]] to a new empty List.
         1. Return _completion_.
       </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -1121,7 +1121,7 @@ contributors: Ron Buckton, Ecma International
               1. Set _completion_ to ThrowCompletion(_error_).
             1. Else,
               1. Set _completion_ to _result_.
-        1. NOTE: After a DisposeCapability record has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
+        1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
         1. Set _disposeCapability_.[[DisposableResourceStack]] to ~empty~.
         1. Return _completion_.
       </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -1119,6 +1119,7 @@ contributors: Ron Buckton, Ecma International
               1. Set _completion_ to ThrowCompletion(_error_).
             1. Else,
               1. Set _completion_ to _result_.
+        1. NOTE: After a DisposeCapability record has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
         1. Return _completion_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -927,7 +927,7 @@ contributors: Ron Buckton, Ecma International
               [[DisposableResourceStack]]
             </td>
             <td>
-              A List of DisposableResource Records, or ~empty~.
+              either *undefined* or a List of DisposableResource Records
             </td>
             <td>
               The resources to be disposed. Resources are added in the order they are initialized, and are disposed in reverse order.
@@ -1018,7 +1018,7 @@ contributors: Ron Buckton, Ecma International
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not ~empty~.
+        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not *undefined*.
         1. If _method_ is not present then,
           1. If _V_ is either *null* or *undefined* and _hint_ is ~sync-dispose~, then
             1. Return ~unused~.
@@ -1108,7 +1108,7 @@ contributors: Ron Buckton, Ecma International
       </h1>
       <dl class="header"></dl>
       <emu-alg>
-        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not ~empty~.
+        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not *undefined*.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
           1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
           1. If _result_.[[Type]] is ~throw~, then
@@ -1122,7 +1122,7 @@ contributors: Ron Buckton, Ecma International
             1. Else,
               1. Set _completion_ to _result_.
         1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
-        1. Set _disposeCapability_.[[DisposableResourceStack]] to ~empty~.
+        1. Set _disposeCapability_.[[DisposableResourceStack]] to *undefined*.
         1. Return _completion_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -927,7 +927,7 @@ contributors: Ron Buckton, Ecma International
               [[DisposableResourceStack]]
             </td>
             <td>
-              A List of DisposableResource Records.
+              A List of DisposableResource Records, or ~empty~.
             </td>
             <td>
               The resources to be disposed. Resources are added in the order they are initialized, and are disposed in reverse order.
@@ -1018,6 +1018,7 @@ contributors: Ron Buckton, Ecma International
       <dl class="header">
       </dl>
       <emu-alg>
+        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not ~empty~.
         1. If _method_ is not present then,
           1. If _V_ is either *null* or *undefined* and _hint_ is ~sync-dispose~, then
             1. Return ~unused~.
@@ -1107,6 +1108,7 @@ contributors: Ron Buckton, Ecma International
       </h1>
       <dl class="header"></dl>
       <emu-alg>
+        1. Assert: _disposeCapability_.[[DisposableResourceStack]] is not ~empty~.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
           1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
           1. If _result_.[[Type]] is ~throw~, then
@@ -1120,6 +1122,7 @@ contributors: Ron Buckton, Ecma International
             1. Else,
               1. Set _completion_ to _result_.
         1. NOTE: After a DisposeCapability record has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded at this point.
+        1. Set _disposeCapability_.[[DisposableResourceStack]] to ~empty~.
         1. Return _completion_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The `DisposeResources` AO fails to indicate that the resources in its `[[DisposableResourceStack]]` slot will no longer be used and can be freed. As a result, a `DisposableStack` will inadvertently hold resources in memory until the `DisposableStack` instance is freed, which is not an intended behavior.

This changes `DisposeResources` to set the `[[DisposableResourceStack]]` to a new empty list, along with a NOTE indicating the resources can be freed.

A PR against ecma262 is being tracked by https://github.com/rbuckton/ecma262/pull/8.

Fixes #191

/cc: @tc39/ecma262-editors 