### PR TITLE
Reduce unnecessary Awaits in blocks containing `await using`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "proposal-explicit-resource-management",
       "version": "0.0.0",
       "license": "SEE LICENSE IN https://tc39.es/ecma262/#sec-copyright-and-software-license",
       "devDependencies": {
@@ -12276,8 +12277,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
       "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/spec.emu
+++ b/spec.emu
@@ -972,10 +972,10 @@ contributors: Ron Buckton, Ecma International
               [[Hint]]
             </td>
             <td>
-              ~sync-dispose~ or ~async-dispose~.
+              ~sync-dispose~, ~async-dispose~, or ~async-from-sync-dispose~.
             </td>
             <td>
-              Indicates whether the resource was added by a `using` declaration or DisposableStack object (~sync-dispose~) or a `await using` declaration or AsyncDisposableStack object (~async-dispose~).
+              Indicates whether the resource was added by a `using` declaration or DisposableStack object (~sync-dispose~), an AsyncDisposableStack object (~async-dispose~), or an `await using` declaration (~async-dispose~ or ~async-from-sync-dispose~).
             </td>
           </tr>
           <tr>
@@ -1045,56 +1045,21 @@ contributors: Ron Buckton, Ecma International
           1. If _V_ is either *null* or *undefined*, then
             1. Set _V_ to *undefined*.
             1. Set _method_ to *undefined*.
+            1. Set _hint_ to ~async-from-sync-dispose~.
           1. Else,
             1. If _V_ is not an Object, throw a *TypeError* exception.
-            1. Set _method_ to ? GetDisposeMethod(_V_, _hint_).
-            1. If _method_ is *undefined*, throw a *TypeError* exception.
+            1. If _hint_ is ~async-dispose~, then
+              1. Set _method_ to ? GetMethod(_V_, @@asyncDispose).
+              1. If _method_ is *undefined*, then
+                1. Set _method_ to ? GetMethod(_V_, @@dispose).
+                1. If _method_ is *undefined*, throw a *TypeError* exception.
+                1. Set _hint_ to ~async-from-sync-dispose~.
+            1. Else,
+              1. Set _method_ to ? GetMethod(_V_, @@dispose).
+              1. If _method_ is *undefined*, throw a *TypeError* exception.
         1. Else,
           1. If IsCallable(_method_) is *false*, throw a *TypeError* exception.
         1. Return the DisposableResource Record { [[ResourceValue]]: _V_, [[Hint]]: _hint_, [[DisposeMethod]]: _method_ }.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-getdisposemethod" type="abstract operation">
-      <h1>
-        GetDisposeMethod (
-          _V_ : an Object,
-          _hint_ : either ~sync-dispose~ or ~async-dispose~,
-        ): either a normal completion containing either a function object or *undefined*, or a throw completion
-      </h1>
-      <dl class="header"></dl>
-      <emu-alg>
-        1. If _hint_ is ~async-dispose~, then
-          1. Let _method_ be ? GetMethod(_V_, @@asyncDispose).
-          1. If _method_ is *undefined*, then
-            1. Set _method_ to ? GetMethod(_V_, @@dispose).
-            1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
-              1. Let _O_ be the *this* value.
-              1. Perform ? Call(_method_, _O_).
-              1. Return *undefined*.
-            1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited.
-            1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
-        1. Else,
-          1. Let _method_ be ? GetMethod(_V_, @@dispose).
-        1. Return _method_.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-dispose" type="abstract operation">
-      <h1>
-        Dispose (
-          _V_ : an Object or *undefined*,
-          _hint_ : either ~sync-dispose~ or ~async-dispose~,
-          _method_ : a function object or *undefined*,
-        ): either a normal completion containing *undefined* or a throw completion
-      </h1>
-      <dl class="header"></dl>
-      <emu-alg>
-        1. If _method_ is *undefined*, let _result_ be *undefined*.
-        1. Else, let _result_ be ? Call(_method_, _V_).
-        1. If _hint_ is ~async-dispose~, then
-          1. Perform ? Await(_result_).
-        1. Return *undefined*.
       </emu-alg>
     </emu-clause>
 
@@ -1103,22 +1068,44 @@ contributors: Ron Buckton, Ecma International
         DisposeResources (
           _disposeCapability_ : a DisposeCapability Record,
           _completion_ : a Completion Record,
+          _ensureAwait_ : a Boolean,
         ): a Completion Record
       </h1>
       <dl class="header"></dl>
       <emu-alg>
+        1. Let _needsAwait_ be *false*.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
-          1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
-          1. If _result_.[[Type]] is ~throw~, then
-            1. If _completion_.[[Type]] is ~throw~, then
-              1. Set _result_ to _result_.[[Value]].
-              1. Let _suppressed_ be _completion_.[[Value]].
-              1. Let _error_ be a newly created *SuppressedError* object.
-              1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, *"error"*, _result_).
-              1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, *"suppressed"*, _suppressed_).
-              1. Set _completion_ to ThrowCompletion(_error_).
-            1. Else,
-              1. Set _completion_ to _result_.
+          1. Let _value_ be _resource_.[[ResourceValue]].
+          1. Let _hint_ be _resource_.[[Hint]].
+          1. Let _method_ be _resource_.[[DisposeMethod]].
+          1. If _hint_ is ~sync-dispose~ and _needsAwait_ is *true* and _ensureAwait_ is *true, then
+            1. Perform ! Await(*undefined*).
+            1. Set _needsAwait_ to *false*.
+          1. If _method_ is not *undefined*, then
+            1. Let _result_ be Completion(Call(_method_, _value_)).
+            1. If _result_ is a throw completion and _needsAwait_ is *true* and _ensureAwait_ is *true*, then
+                1. Perform ! Await(*undefined*).
+                1. Set _needsAwait_ to *false*.
+            1. If _result_ is a normal completion, then
+              1. If _hint_ is ~async-dispose~, then
+                1. Set _result_ to Completion(Await(_result_.[[Value]])).
+                1. Set _needsAwait_ to *false*.
+              1. Else, if _hint_ is ~async-from-sync-dispose~, then
+                1. Set _needsAwait_ to *true*.
+            1. If _result_ is a throw completion, then
+              1. If _completion_ is a throw completion, then
+                1. Set _result_ to _result_.[[Value]].
+                1. Let _suppressed_ be _completion_.[[Value]].
+                1. Let _error_ be a newly created *SuppressedError* object.
+                1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, *"error"*, _result_).
+                1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_error_, *"suppressed"*, _suppressed_).
+                1. Set _completion_ to ThrowCompletion(_error_).
+              1. Else,
+                1. Set _completion_ to _result_.
+          1. Else, if _hint_ is ~async-from-sync-dispose~, then
+            1. Set _needsAwait_ to *true*.
+        1. If _needsAwait_ is *true* and _ensureAwait_ is *true*, then
+          1. Perform ! Await(*undefined*).
         1. Return _completion_.
       </emu-alg>
     </emu-clause>
@@ -2550,7 +2537,7 @@ contributors: Ron Buckton, Ecma International
         1. Perform BlockDeclarationInstantiation(|StatementList|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
         1. Let _blockValue_ be the result of evaluating |StatementList|.
-        1. <ins>Set _blockValue_ to DisposeResources(_blockEnv_.[[DisposeCapability]], _blockValue_).</ins>
+        1. <ins>Set _blockValue_ to DisposeResources(_blockEnv_.[[DisposeCapability]], _blockValue_, *true*).</ins>
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _blockValue_.
       </emu-alg>
@@ -2898,7 +2885,7 @@ contributors: Ron Buckton, Ecma International
           1. Set the running execution context's LexicalEnvironment to _loopEnv_.
           1. Let _forDcl_ be Completion(Evaluation of |LexicalDeclaration|).
           1. If _forDcl_ is an abrupt completion, then
-            1. <ins>Set _forDcl_ to Completion(DisposeResources(_loopEnv_.[[DisposeCapability]], _forDcl_)).</ins>
+            1. <ins>Set _forDcl_ to Completion(DisposeResources(_loopEnv_.[[DisposeCapability]], _forDcl_, *true*)).</ins>
             1. <ins>Assert: _forDcl_ is an abrupt completion.</ins>
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. Return ? _forDcl_.
@@ -2906,7 +2893,7 @@ contributors: Ron Buckton, Ecma International
           1. If the first |Expression| is present, let _test_ be the first |Expression|; otherwise, let _test_ be ~empty~.
           1. If the second |Expression| is present, let _increment_ be the second |Expression|; otherwise, let _increment_ be ~empty~.
           1. Let _bodyResult_ be Completion(ForBodyEvaluation(_test_, _increment_, |Statement|, _perIterationLets_, _labelSet_)).
-          1. <ins>Set _bodyResult_ to Completion(DisposeResources(_loopEnv_.[[DisposeCapability]], _bodyResult_)).</ins>
+          1. <ins>Set _bodyResult_ to Completion(DisposeResources(_loopEnv_.[[DisposeCapability]], _bodyResult_, *true*)).</ins>
           1. <ins>Assert: If _bodyResult_.[[Type]] is ~normal~, then _bodyResult_.[[Value]] is not ~empty~.</ins>
           1. Set the running execution context's LexicalEnvironment to _oldEnv_.
           1. Return ? _bodyResult_.
@@ -3037,7 +3024,7 @@ contributors: Ron Buckton, Ecma International
                 1. <ins>Let _status_ be Completion(InitializeReferencedBinding(_lhsRef_, _nextValue_, _hint_)).</ins>
             1. If _status_ is an abrupt completion, then
               1. <ins>If _iterationEnv_ is not *undefined*, then</ins>
-                1. <ins>Set _status_ to Completion(DisposeResources(_iterationEnv_.[[DisposeCapability]], _status_)).</ins>
+                1. <ins>Set _status_ to Completion(DisposeResources(_iterationEnv_.[[DisposeCapability]], _status_, *true*)).</ins>
                 1. <ins>Assert: _status_ is an abrupt completion.</ins>
               1. Set the running execution context's LexicalEnvironment to _oldEnv_.
               1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
@@ -3048,7 +3035,7 @@ contributors: Ron Buckton, Ecma International
                 1. Return ? IteratorClose(_iteratorRecord_, _status_).
             1. Let _result_ be Completion(Evaluation of _stmt_).
             1. <ins>If _iterationEnv_ is not *undefined*, then</ins>
-              1. <ins>Set _result_ to Completion(DisposeResources(_iterationEnv_.[[DisposeCapability]], _result_)).</ins>
+              1. <ins>Set _result_ to Completion(DisposeResources(_iterationEnv_.[[DisposeCapability]], _result_, *true*)).</ins>
             1. Set the running execution context's LexicalEnvironment to _oldEnv_.
             1. If LoopContinues(_result_, _labelSet_) is *false*, then
               1. If _iterationKind_ is ~enumerate~, then
@@ -3078,7 +3065,7 @@ contributors: Ron Buckton, Ecma International
         1. Perform BlockDeclarationInstantiation(|CaseBlock|, _blockEnv_).
         1. Set the running execution context's LexicalEnvironment to _blockEnv_.
         1. Let _R_ be Completion(CaseBlockEvaluation of |CaseBlock| with argument _switchValue_).
-        1. <ins>Set _R_ to Completion(DisposeResources(_blockEnv_.[[DisposeCapability]], _R_)).</ins>
+        1. <ins>Set _R_ to Completion(DisposeResources(_blockEnv_.[[DisposeCapability]], _R_, *true*)).</ins>
         1. <ins>Assert: If _R_.[[Type]] is ~normal~, then _R_.[[Value]] is not ~empty~.</ins>
         1. Set the running execution context's LexicalEnvironment to _oldEnv_.
         1. Return _R_.
@@ -3168,7 +3155,7 @@ contributors: Ron Buckton, Ecma International
         1. Let _result_ be Completion(Evaluation of |StatementList|).
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Assert: _env_ is a Declarative Environment Record.
-        1. Return ? DisposeResources(_env_.[[DisposeCapability]], _result_).
+        1. Return ? DisposeResources(_env_.[[DisposeCapability]], _result_, *true*).
       </emu-alg>
       </ins>
     </emu-clause>
@@ -3284,7 +3271,7 @@ contributors: Ron Buckton, Ecma International
         1. <del>Return ? Evaluation of |ClassStaticBlockStatementList|.</del>
         1. <ins>Let _result_ be Completion(Evaluation of |ClassStaticBlockStatementList|).</ins>
         1. <ins>Let _env_ be the running execution context's LexicalEnvironment.</ins>
-        1. <ins>Return ? DisposeResources(_env_.[[DisposeCapability]], _result_).</ins>
+        1. <ins>Return ? DisposeResources(_env_.[[DisposeCapability]], _result_, *true*).</ins>
       </emu-alg>
     </emu-clause>
 
@@ -4008,7 +3995,7 @@ contributors: Ron Buckton, Ecma International
               1. Assert: _capability_ is not present.
               1. Push _moduleContext_ onto the execution context stack; _moduleContext_ is now the running execution context.
               1. Let _result_ be Completion(Evaluation of _module_.[[ECMAScriptCode]]).
-              1. <ins>Set _result_ to Completion(DisposeResources(_env_.[[DisposeCapability]], _result_)).</ins>
+              1. <ins>Set _result_ to Completion(DisposeResources(_env_.[[DisposeCapability]], _result_, *true*)).</ins>
               1. Suspend _moduleContext_ and remove it from the execution context stack.
               1. Resume the context that is now on the top of the execution context stack as the running execution context.
               1. If _result_ is an abrupt completion, then
@@ -4500,7 +4487,7 @@ contributors: Ron Buckton, Ecma International
           1. Perform ? RequireInternalSlot(_disposableStack_, [[DisposableState]]).
           1. If _disposableStack_.[[DisposableState]] is ~disposed~, return *undefined*.
           1. Set _disposableStack_.[[DisposableState]] to ~disposed~.
-          1. Return DisposeResources(_disposableStack_.[[DisposeCapability]], NormalCompletion(*undefined*)).
+          1. Return DisposeResources(_disposableStack_.[[DisposeCapability]], NormalCompletion(*undefined*), *false*).
         </emu-alg>
       </emu-clause>
 
@@ -4710,7 +4697,7 @@ contributors: Ron Buckton, Ecma International
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).
             1. Return _promiseCapability_.[[Promise]].
           1. Set _asyncDisposableStack_.[[AsyncDisposableState]] to ~disposed~.
-          1. Let _result_ be DisposeResources(_asyncDisposableStack_.[[DisposeCapability]], NormalCompletion(*undefined*)).
+          1. Let _result_ be DisposeResources(_asyncDisposableStack_.[[DisposeCapability]], NormalCompletion(*undefined*), *false*).
           1. IfAbruptRejectPromise(_result_, _promiseCapability_).
           1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _result_ &raquo;).
           1. Return _promiseCapability_.[[Promise]].


### PR DESCRIPTION
Per https://github.com/tc39/proposal-explicit-resource-management/issues/196#issuecomment-1646145514, this reduces the number of `Await`s in blocks containing `await using` and in `AsyncDisposableStack` to only those necessary to meet the requirement that exiting a block in which an `await using` is evaluated should *always* `Await` at least once, even if the resource defined by `await using` is `null`, `undefined`, or synchronous disposable (i.e., an object with a `@@dispose` instead of an `@@asyncDispose`).

As currently specified, the following code results in three `Await`s when only one is necessary:

```js
{
  await using x = null, y = null, z = { [Symbol.dispose]() {} };
}
```

This was also the case in an `AsyncDisposableStack` containing synchronous disposables:

```js
const stack = new AsyncDisposableStack();
stack.use({ [Symbol.dispose]() { } });
stack.use({ [Symbol.dispose]() { } });
stack.use({ [Symbol.dispose]() { } });
await stack.disposeAsync(); // Awaits four times, including the explicit await on this line.
```

This PR changes this behavior such that we only need an implicit `Await` in the following cases:

- Disposal of an _async resource_[^1], so long as it does not throw synchronously.
- When the disposal of an _async resource_ or _async-from-sync resource_[^2] throws synchronously after a preceding _async-from-sync resource_ disposed normally.
- When transitioning from the normal disposal of an _async-from-sync resource_ declared in an `await using`, to the disposal of a _sync resource_[^3] declared in a `using`.
- When the normal disposal of an _async-from-sync resource_ is the last disposal performed for a scope.

**Example 1**
```js
try {
  using A = syncRes;
  await using B = asyncRes;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

Here, `B` has an implicit `Await` for its disposal, which means (per current proposal text):
- `B[@@asyncDispose]()` is invoked in the same turn as `HAPPENS_BEFORE`.
- `A[@@dispose]()` is invoked in the following turn (unless `B[@@asyncDispose]()` threw synchronously).
- `HAPPENS_AFTER` happens in the same turn as `A[@@dispose]()`.

**Example 2**
```js
try {
  await using A = syncRes, B = asyncRes;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

Here, `A` and `B` both have implicit `Await`s, which means (per current proposal text):
- `B[@@asyncDispose]()` is invoked in the same turn as `HAPPENS_BEFORE`.
- `A[@@dispose]()` is invoked in the following turn (unless `B[@@asyncDispose]()` threw synchronously).
- `HAPPENS_AFTER` happens in the following turn (unless `A[@@dispose]()` threw synchronously).

**Example 3**
```js
try {
  await using A = asyncRes, B = syncRes;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

Here, only `A` needs to have an implicit `Await`, since `B` will dispose synchronously, which means (proposed change):
- `B[@@dispose]()` is invoked in the same turn as `HAPPENS_BEFORE`.
- `A[@@asyncDispose]()` is invoked in the same turn as `B[@@dispose]()`.
- `HAPPENS_AFTER` happens in the following turn (unless both `B[@@dispose]()` and `A[@@asyncDispose]()` threw synchronously).

Note that this means that the above could all occur synchronously if both `B[@@dispose]()` and `A[@@asyncDispose]()` were to throw synchronously, though that is consistent with `await` in general. However, if `A[@@asyncDispose]()` were to throw synchronously but `B[@@dispose]()` were to complete synchronously we would need to introduce an implicit `Await` to ensure we account for the successful disposal.

This PR also removes unnecessary `Await`s from `AsyncDisposableStack.prototype.disposeAsync()` since you must either `await` or invoke `.then()` on the result to observe its effects.

Fixes #196
Fixes #208

[^1]: An _async resource_ is an object with an `@@asyncDispose` method initialized in an `await using` declaration.
[^2]: An _sync-from-sync resource_ is either `null`, `undefined`, or an object with a `@@dispose` method (but not an `@@asyncDispose` method) initialized in an `await using` declaration.
[^3]: A _sync resource_ is either `null`, `undefined`, or an object with a `@@dispose` method initialized in a `using` declaration.