### PR TITLE
Fix `GetDisposeMethod` to match consensus

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1068,12 +1068,13 @@ contributors: Ron Buckton, Ecma International
           1. Let _method_ be ? GetMethod(_V_, @@asyncDispose).
           1. If _method_ is *undefined*, then
             1. Set _method_ to ? GetMethod(_V_, @@dispose).
-            1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
-              1. Let _O_ be the *this* value.
-              1. Perform ? Call(_method_, _O_).
-              1. Return *undefined*.
-            1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited.
-            1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
+            1. If _method_ is not *undefined*, then
+              1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
+                1. Let _O_ be the *this* value.
+                1. Perform ? Call(_method_, _O_).
+                1. Return *undefined*.
+              1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited.
+              1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
         1. Else,
           1. Let _method_ be ? GetMethod(_V_, @@dispose).
         1. Return _method_.


### PR DESCRIPTION
PR #180 reached consensus in the July, 2023 TC39 plenary, but there was a typo in the `GetDisposeMethod` AO that results a normative change that was not intentional nor part of the consensus. It has long been the intent that we should throw early when `@@asyncDispose` or `@@dispose` is not found on a resource, but #180 inadvertently lost this requirement. This PR intends to align the proposal text with the actual consensus.

A PR against ecma262 is being tracked in https://github.com/rbuckton/ecma262/pull/5.

Fixes #208