### PR TITLE
Add PromiseCapability wrapper around sync dispose used in an `await using`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1065,12 +1065,16 @@ contributors: Ron Buckton, Ecma International
           1. Let _method_ be ? GetMethod(_V_, @@asyncDispose).
           1. If _method_ is *undefined*, then
             1. Set _method_ to ? GetMethod(_V_, @@dispose).
-            1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
-              1. Let _O_ be the *this* value.
-              1. Perform ? Call(_method_, _O_).
-              1. Return *undefined*.
-            1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited.
-            1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
+            1. If _method_ is not *undefined*, then
+              1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
+                1. Let _O_ be the *this* value.
+                1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+                1. Let _result_ be Completion(Call(_method_, _O_)).
+                1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+                1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
+                1. Return _promiseCapability_.[[Promise]].
+              1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited and that any exception thrown will not be thrown synchronously.
+              1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
         1. Else,
           1. Let _method_ be ? GetMethod(_V_, @@dispose).
         1. Return _method_.


### PR DESCRIPTION
Per discussion in https://github.com/tc39/proposal-explicit-resource-management/pull/216#issuecomment-2015449095, this adds a `PromiseCapability` to the wrapper function created around a `@@dispose` method read by an `await using` declaration to ensure that any errors thrown by `@@dispose` are not thrown synchronously. This is in keeping with the mechanism used in `%AsyncFromSyncIteratorPrototype%.next()`.