### PR TITLE
Reduce unnecessary Awaits for nullish values in blocks containing `await using`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1110,7 +1110,7 @@ contributors: Ron Buckton, Ecma International
       <emu-alg>
         1. Let _needsAwait_ be *false*.
         1. Let _hasAwaited_ be *false*.
-        1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
+        1. For each element _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
           1. Let _value_ be _resource_.[[ResourceValue]].
           1. Let _hint_ be _resource_.[[Hint]].
           1. Let _method_ be _resource_.[[DisposeMethod]].

--- a/spec.emu
+++ b/spec.emu
@@ -1117,7 +1117,6 @@ contributors: Ron Buckton, Ecma International
           1. If _hint_ is ~sync-dispose~ and _needsAwait_ is *true* and _hasAwaited_ is *false*, then
             1. Perform ! Await(*undefined*).
             1. Set _needsAwait_ to *false*.
-            1. Set _hasAwaited_ to *false*.
           1. If _method_ is not *undefined*, then
             1. Let _result_ be Completion(Call(_method_, _value_)).
             1. If _result_ is a normal completion and _hint_ is ~async-dispose~, then

--- a/spec.emu
+++ b/spec.emu
@@ -1108,18 +1108,37 @@ contributors: Ron Buckton, Ecma International
       </h1>
       <dl class="header"></dl>
       <emu-alg>
+        1. Let _needsAwait_ be *false*.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
-          1. Let _result_ be Dispose(_resource_.[[ResourceValue]], _resource_.[[Hint]], _resource_.[[DisposeMethod]]).
-          1. If _result_.[[Type]] is ~throw~, then
-            1. If _completion_.[[Type]] is ~throw~, then
-              1. Set _result_ to _result_.[[Value]].
-              1. Let _suppressed_ be _completion_.[[Value]].
-              1. Let _error_ be a newly created *SuppressedError* object.
-              1. Perform CreateNonEnumerableDataPropertyOrThrow(_error_, *"error"*, _result_).
-              1. Perform CreateNonEnumerableDataPropertyOrThrow(_error_, *"suppressed"*, _suppressed_).
-              1. Set _completion_ to ThrowCompletion(_error_).
+          1. Let _value_ be _resource_.[[ResourceValue]].
+          1. Let _hint_ be _resource_.[[Hint]].
+          1. Let _method_ be _resource_.[[DisposeMethod]].
+          1. If _hint_ is ~sync-dispose~ and _needsAwait_ is *true*, then
+            1. Perform ! Await(*undefined*).
+            1. Set _needsAwait_ to *false*.
+          1. If _method_ is not *undefined*, then
+            1. If _needsAwait_ is *true*, then
+              1. Perform ! Await(*undefined*).
+              1. Set _needsAwait_ to *false*.
+            1. Let _result_ be Completion(Call(_method_, _value_)).
+            1. If _result_ is a normal completion and _hint_ is ~async-dispose~, then
+              1. Set _result_ to Completion(Await(_result_.[[Value]])).
+            1. If _result_ is a throw completion, then
+              1. If _completion_ is a throw completion, then
+                1. Set _result_ to _result_.[[Value]].
+                1. Let _suppressed_ be _completion_.[[Value]].
+                1. Let _error_ be a newly created *SuppressedError* object.
+                1. Perform CreateNonEnumerableDataPropertyOrThrow(_error_, *"error"*, _result_).
+                1. Perform CreateNonEnumerableDataPropertyOrThrow(_error_, *"suppressed"*, _suppressed_).
+                1. Set _completion_ to ThrowCompletion(_error_).
+              1. Else,
+                1. Set _completion_ to _result_.
             1. Else,
-              1. Set _completion_ to _result_.
+              1. Assert: _hint_ is ~async-dispose~.
+              1. Set _needsAwait_ to *true*.
+              1. NOTE: This can only indicate a case where either *null* or *undefined* was the initialized value of an `await using` declaration.
+        1. If _needsAwait_ is *true*, then
+          1. Perform ! Await(*undefined*).
         1. Return _completion_.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -1109,20 +1109,20 @@ contributors: Ron Buckton, Ecma International
       <dl class="header"></dl>
       <emu-alg>
         1. Let _needsAwait_ be *false*.
+        1. Let _hasAwaited_ be *false*.
         1. For each _resource_ of _disposeCapability_.[[DisposableResourceStack]], in reverse list order, do
           1. Let _value_ be _resource_.[[ResourceValue]].
           1. Let _hint_ be _resource_.[[Hint]].
           1. Let _method_ be _resource_.[[DisposeMethod]].
-          1. If _hint_ is ~sync-dispose~ and _needsAwait_ is *true*, then
+          1. If _hint_ is ~sync-dispose~ and _needsAwait_ is *true* and _hasAwaited_ is *false*, then
             1. Perform ! Await(*undefined*).
             1. Set _needsAwait_ to *false*.
+            1. Set _hasAwaited_ to *false*.
           1. If _method_ is not *undefined*, then
-            1. If _needsAwait_ is *true*, then
-              1. Perform ! Await(*undefined*).
-              1. Set _needsAwait_ to *false*.
             1. Let _result_ be Completion(Call(_method_, _value_)).
             1. If _result_ is a normal completion and _hint_ is ~async-dispose~, then
-              1. Set _result_ to Completion(Await(_result_.[[Value]])).
+                1. Set _result_ to Completion(Await(_result_.[[Value]])).
+                1. Set _hasAwaited_ to *true*.
             1. If _result_ is a throw completion, then
               1. If _completion_ is a throw completion, then
                 1. Set _result_ to _result_.[[Value]].
@@ -1137,7 +1137,7 @@ contributors: Ron Buckton, Ecma International
               1. Assert: _hint_ is ~async-dispose~.
               1. Set _needsAwait_ to *true*.
               1. NOTE: This can only indicate a case where either *null* or *undefined* was the initialized value of an `await using` declaration.
-        1. If _needsAwait_ is *true*, then
+        1. If _needsAwait_ is *true* and _hasAwaited_ is *false*, then
           1. Perform ! Await(*undefined*).
         1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded in implementations, such as by garbage collection, at this point.
         1. Set _disposeCapability_.[[DisposableResourceStack]] to a new empty List.

--- a/spec.emu
+++ b/spec.emu
@@ -1121,8 +1121,8 @@ contributors: Ron Buckton, Ecma International
           1. If _method_ is not *undefined*, then
             1. Let _result_ be Completion(Call(_method_, _value_)).
             1. If _result_ is a normal completion and _hint_ is ~async-dispose~, then
-                1. Set _result_ to Completion(Await(_result_.[[Value]])).
-                1. Set _hasAwaited_ to *true*.
+              1. Set _result_ to Completion(Await(_result_.[[Value]])).
+              1. Set _hasAwaited_ to *true*.
             1. If _result_ is a throw completion, then
               1. If _completion_ is a throw completion, then
                 1. Set _result_ to _result_.[[Value]].

--- a/spec.emu
+++ b/spec.emu
@@ -1132,10 +1132,10 @@ contributors: Ron Buckton, Ecma International
                 1. Set _completion_ to ThrowCompletion(_error_).
               1. Else,
                 1. Set _completion_ to _result_.
-            1. Else,
-              1. Assert: _hint_ is ~async-dispose~.
-              1. Set _needsAwait_ to *true*.
-              1. NOTE: This can only indicate a case where either *null* or *undefined* was the initialized value of an `await using` declaration.
+          1. Else,
+            1. Assert: _hint_ is ~async-dispose~.
+            1. Set _needsAwait_ to *true*.
+            1. NOTE: This can only indicate a case where either *null* or *undefined* was the initialized value of an `await using` declaration.
         1. If _needsAwait_ is *true* and _hasAwaited_ is *false*, then
           1. Perform ! Await(*undefined*).
         1. NOTE: After _disposeCapability_ has been disposed, it will never be used again. The contents of _disposeCapability_.[[DisposableResourceStack]] can be discarded in implementations, such as by garbage collection, at this point.

--- a/spec.emu
+++ b/spec.emu
@@ -1065,12 +1065,16 @@ contributors: Ron Buckton, Ecma International
           1. Let _method_ be ? GetMethod(_V_, @@asyncDispose).
           1. If _method_ is *undefined*, then
             1. Set _method_ to ? GetMethod(_V_, @@dispose).
-            1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
-              1. Let _O_ be the *this* value.
-              1. Perform ? Call(_method_, _O_).
-              1. Return *undefined*.
-            1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited.
-            1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
+            1. If _method_ is not *undefined*, then
+              1. Let _closure_ be a new Abstract Closure with no parameters that captures _method_ and performs the following steps when called:
+                1. Let _O_ be the *this* value.
+                1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+                1. Let _result_ be Completion(Call(_method_, _O_)).
+                1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+                1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
+                1. Return _promiseCapability_.[[Promise]].
+              1. NOTE: This function is not observable to user code. It is used to ensure that a Promise returned from a synchronous `@@dispose` method will not be awaited and that any exception thrown will not be thrown synchronously.
+              1. Return CreateBuiltinFunction(_closure_, 0, *""*, « »).
         1. Else,
           1. Let _method_ be ? GetMethod(_V_, @@dispose).
         1. Return _method_.


### PR DESCRIPTION
This is an alternative to #216 and is based on another fix in #218.

Per https://github.com/tc39/proposal-explicit-resource-management/issues/196#issuecomment-1646145514, this reduces the number of `Await`s in blocks containing `await using` and in `AsyncDisposableStack` by collapsing the `Await`s introduced for `null` or `undefined` resources to a single `Await`.

As currently specified, the following code results in three `Await`s when only one is necessary:

```js
{
  await using x = null, y = undefined, z = { [Symbol.dispose]() {} };
}
```

This was also the case in an `AsyncDisposableStack` containing synchronous disposables:

```js
const stack = new AsyncDisposableStack();
stack.use(null);
stack.use(undefined);
stack.use({ [Symbol.dispose]() { } });
await stack.disposeAsync(); // Awaits four times, including the explicit await on this line.
```

This PR changes this behavior such that we only need an implicit `Await` in the following cases:

- Disposal of an _async resource_[^1] or a non-nullish _async-from-sync resource_[^2], so long as it does not throw synchronously.
- When transitioning from a `null` or `undefined` _async-from-sync resource_ to an _async resource_, non-nullish _async-from-sync resource_, or _sync resource_[^3].
- When transitioning from a `null` or `undeifned` _async-from-sync resource_ is the last disposal performed for a scope.

**Example 1**
```js
try {
  using A = syncRes;
  await using B = null, C = undefined;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

1. `C` is `undefined` so no disposal happens, but we track that an `Await` must occur. [+0 turns]
1. `B` is `null` so no disposal happens, but we track that an `Await` must occur. [+0 turns]
1. `A` is neither `null` nor `undefined` and we have tracked that an `Await` must occur, so we `Await(undefined)`. [+1 turn]
1. `A[@@dispose]()` is invoked in the following turn. [+0 turns]
1. `HAPPENS_AFTER` happens in the same turn as `A[@@dispose]()`, but a turn after `HAPPENS_BEFORE`.

**Example 2**
```js
try {
  using A = syncRes;
  await using B = null, C = asyncRes;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

1. `C` is neither `null` nor `undefined` so we invoke its `@@asyncDispose` method. If it completes normally we `Await` the result [+1 turns], but if it throws we continue on the same turn [+0 turns].
1. `B` is `null` so no disposal happens, but we track that an `Await` must occur. [+0 turns]
1. `A` is neither `null` nor `undefined` and we have tracked that an `Await` must occur, so we `Await(undefined)`. [+1 turns]
1. `A[@@dispose]()` is invoked in the following turn. [+0 turns]
1. `HAPPENS_AFTER` happens in the same turn as `A[@@dispose]()`, but between 1-2 turns after `HAPPENS_BEFORE`.

**Example 3**
```js
try {
  using A = syncRes;
  await using B = asyncRes, C = null;
  HAPPENS_BEFORE
} catch { }
HAPPENS_AFTER
```

1. `C` is `null` so no disposal happens, but we track that an `Await` must occur. [+0 turns]
1. `B` is neither `null` nor `undefined` and we have tracked that an `Await` must occur, so we `Await(undefined)`. [+1 turns]
1. Next, we invoke `B`'s `@@asyncDispose` method. If it completes normally we `Await` the result [+1 turns], but if it throws we continue on the same turn [+0 turns].
1. `A` is neither `null` nor `undefined` so we invoke `A[@@dispose]()` either on the turn after `B`'s disposal (if it was normal), or on the same turn (if it threw). [+0 turns]
1. `HAPPENS_AFTER` happens in the same turn as `A[@@dispose]()`, but between 1-2 turns after `HAPPENS_BEFORE`.

It is important to note that a synchronous throw completion from a call to `@@asyncDispose` will result in the `Await` being passed over, but this is consistent with `for await` and `AsyncIterator.next()` behavior. Following #218, this is unlikely to occur for a `@@dispose` method as it will be automatically wrapped in a new `PromiseCapability`, though it is still possible to throw synchronously if `Promise.prototype.then` is patched to throw an exception synchronously.

This PR also removes unnecessary `Await`s for `null`/`undefined` resources in `AsyncDisposableStack.prototype.disposeAsync()`.

The PR against ecma262 is being tracked in https://github.com/rbuckton/ecma262/pull/10

Fixes #196
Fixes #208

[^1]: An _async resource_ is an object with an `@@asyncDispose` method initialized in an `await using` declaration.
[^2]: An _sync-from-sync resource_ is either `null`, `undefined`, or an object with a `@@dispose` method (but not an `@@asyncDispose` method) initialized in an `await using` declaration.
[^3]: A _sync resource_ is either `null`, `undefined`, or an object with a `@@dispose` method initialized in a `using` declaration.