### PR TITLE
Remove superfluous ClassBody restriction

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -2659,7 +2659,7 @@ contributors: Ron Buckton, Ecma International
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
           <li>
-            It is a Syntax Error if the goal symbol is |Script| and |UsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, |ClassStaticBlockBody|, or |ClassBody|.
+            It is a Syntax Error if the goal symbol is |Script| and |UsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
           </li>
         </ul>
         <emu-grammar>
@@ -2675,7 +2675,7 @@ contributors: Ron Buckton, Ecma International
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
           <li>
-            It is a Syntax Error if the goal symbol is |Script| and |AwaitUsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, |ClassStaticBlockBody|, or |ClassBody|.
+            It is a Syntax Error if the goal symbol is |Script| and |AwaitUsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
           </li>
         </ul>
         <emu-note>


### PR DESCRIPTION
Per https://github.com/tc39/ecma262/pull/3000#pullrequestreview-1863242577, the `ClassBody` restriction in the early errors for `UsingDeclaration` and `AwaitUsingDeclaration` is superfluous as it cannot occur, thus should be removed.