### PR TITLE
Fix missing lookahead restriction

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -4041,7 +4041,7 @@ contributors: Ron Buckton, Ecma International
             `export` ExportFromClause FromClause `;`
             `export` NamedExports `;`
             `export` VariableStatement[~Yield, +Await]
-            `export` <ins>[lookahead != `using`]</ins> Declaration[~Yield, +Await]
+            `export` <ins>[lookahead &notin; { `using`, `await` }]</ins> Declaration[~Yield, +Await]
             `export` `default` HoistableDeclaration[~Yield, +Await, +Default]
             `export` `default` ClassDeclaration[~Yield, +Await, +Default]
             `export` `default` [lookahead &notin; {`function`, `async` [no |LineTerminator| here] `function`, `class`}] AssignmentExpression[+In, ~Yield, +Await] `;`


### PR DESCRIPTION
This fixes a missing lookahead restriction to prevent `export await using` like we do for `export using` that was overlooked when we chose `await using` over `using await`.

The PR against ecma262 is being tracked in https://github.com/rbuckton/ecma262/pull/4