### PR TITLE
fix a syntax error in the README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ finally {
 ```js
 // async generators
 async function * g() {
-  const handle = acquireStream(); // critical resource
+  const stream = acquireStream(); // critical resource
   try {
     ...
   }


### PR DESCRIPTION
In the README, a code snippet uses the "stream" variable to close the stream, but it is defined as "handle". This PR renames the "handle" variable to "stream".

```ts
async function * g() {
  const handle = acquireStream(); // critical resource
  try {
    ...
  }
  finally {
    await stream.close(); // cleanup
  }
}
```